### PR TITLE
implement two steps for forging batch

### DIFF
--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -57,6 +57,8 @@ contract Rollup is Ownable, RollupHelpers, RollupInterface {
 
   // maximum on-chain transactions
   uint constant MAX_ONCHAIN_TX = 100;
+  // current on chain transactions
+  uint currentOnChainTx = 0;
 
   /**
    * @dev Event called when a deposit has been made
@@ -159,6 +161,7 @@ contract Rollup is Ownable, RollupHelpers, RollupInterface {
     require(depositAmount > 0, 'Deposit amount must be greater than 0');
     require(withdrawAddress != address(0), 'Must specify withdraw address');
     require(tokenList[tokenId] != address(0), 'token has not been registered');
+    require(currentOnChainTx < MAX_ONCHAIN_TX, 'Reached maximum number of on-chain transactions');
 
     // Build entry deposit and get its hash
     Entry memory depositEntry = buildEntryDeposit(lastBalanceTreeIndex, depositAmount,
@@ -176,6 +179,9 @@ contract Rollup is Ownable, RollupHelpers, RollupInterface {
 
     // Update total on-chain fees
     totalFillingOnChainFee += msg.value;
+
+    // Update number of on-chain transactions
+    currentOnChainTx++;
 
     emit Deposit(lastBalanceTreeIndex, depositAmount, tokenId, babyPubKey[0], babyPubKey[1],
       withdrawAddress);
@@ -259,6 +265,9 @@ contract Rollup is Ownable, RollupHelpers, RollupInterface {
     totalMinningOnChainFee = totalFillingOnChainFee;
     totalFillingOnChainFee = 0;
 
+    // Update number of on-chain transactions
+    currentOnChainTx = 0;
+
     // event with all compressed transactions given its batch number
     emit ForgeBatch(getStateDepth() - 1, compressedTxs);
   }
@@ -330,6 +339,7 @@ contract Rollup is Ownable, RollupHelpers, RollupInterface {
   ) public payable{
 
     require(msg.value >= FEE_ONCHAIN_TX, 'Amount deposited less than fee required');
+    require(currentOnChainTx < MAX_ONCHAIN_TX, 'Reached maximum number of on-chain transactions');
 
     // build 'key' and 'value' for balance tree
     uint256 keyBalanceTree = idBalanceTree;
@@ -352,6 +362,9 @@ contract Rollup is Ownable, RollupHelpers, RollupInterface {
 
     // Update total on-chain fees
     totalFillingOnChainFee += msg.value;
+
+    // Update number of on-chain transactions
+    currentOnChainTx++;
 
     // Withdraw token from rollup smart contract to withdraw address
     require(withdrawToken(tokenId, msg.sender, amount), 'Fail ERC20 withdraw');
@@ -386,6 +399,7 @@ contract Rollup is Ownable, RollupHelpers, RollupInterface {
   ) public payable{
 
     require(msg.value >= FEE_ONCHAIN_TX, 'Amount deposited less than fee required');
+    require(currentOnChainTx < MAX_ONCHAIN_TX, 'Reached maximum number of on-chain transactions');
 
     // build 'key' and 'value' for balance tree
     uint256 keyBalanceTree = uint256(idBalanceTree);
@@ -408,6 +422,9 @@ contract Rollup is Ownable, RollupHelpers, RollupInterface {
 
     // Update total on-chain fees
     totalFillingOnChainFee += msg.value;
+
+    // Update number of on-chain transactions
+    currentOnChainTx++;
 
     // Get token deposit on rollup smart contract
     require(depositToken(tokenId, amountDeposit), 'Fail deposit ERC20 transaction');

--- a/contracts/lib/RollupHelpers.sol
+++ b/contracts/lib/RollupHelpers.sol
@@ -27,6 +27,7 @@ contract RollupHelpers {
   }
 
   uint constant bytesOffChainTx = 3*2 + 2 + 2;
+  uint constant rField = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
 
   /**
    * @dev Load poseidon smart contract
@@ -51,7 +52,6 @@ contract RollupHelpers {
    * @return poseidon hash
    */
   function multiHash(uint256[] memory inputs) internal view returns (uint256){
-    uint rField = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
     uint lenInputs = inputs.length;
     uint totalHash = 0;
     for(uint i = 0; i < lenInputs; i += 5) {
@@ -296,8 +296,6 @@ contract RollupHelpers {
    * @return hash of all off-chain transactions
    */
   function hashOffChainTxV2(bytes memory offChainTx, uint256 maxTx) internal pure returns (uint256) {
-    uint256 r = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
-
     bytes memory hashOffTx = new bytes(maxTx*bytesOffChainTx);
     Memory.Cursor memory c = Memory.read(offChainTx);
     uint ptr = 0;
@@ -307,7 +305,7 @@ contract RollupHelpers {
       ptr++;
     }
     uint256 hashOff = uint256(sha256(hashOffTx));
-    return hashOff % r;
+    return hashOff % rField;
   }
 
   /**

--- a/contracts/test/RollupPoSTest.sol
+++ b/contracts/test/RollupPoSTest.sol
@@ -4,90 +4,109 @@ import "../RollupPoS.sol";
 
 contract RollupPoSTest is RollupPoS {
 
-  constructor( address _rollup) RollupPoS(_rollup) public {}
+    constructor( address _rollup) RollupPoS(_rollup) public {}
 
-  uint public blockNumber;
+    uint public blockNumber;
 
-  function getBlockNumber() public view returns (uint) {
-    return blockNumber;
-  }
-
-  function setBlockNumber(uint bn) public {
-    blockNumber = bn;
-  }
-
-  function setBlockForged(uint32 slot) public {
-    fullFilled[slot] = true;
-  }
-
-  function getRaffleWinnerTest(uint32 slot, uint64 luckyNumber) public view returns (uint32 winner) {
-    // No negative era
-    uint32 era = slot / SLOTS_PER_ERA;
-
-    // Only accept raffle for present and past eras
-    require (era <= currentEra()+1, "No access to not done raffles");
-
-    uint32 ri;
-    if (raffles[era].era == era) {
-        ri = era;
-    } else if (era > lastInitializedRaffle) {
-        ri = lastInitializedRaffle;
-    } else {
-        require(false, "Raffle not initialized for that era");
+    function getBlockNumber() public view returns (uint) {
+        return blockNumber;
     }
 
-    Raffle storage raffle = raffles[ri];
+    function setBlockNumber(uint bn) public {
+        blockNumber = bn;
+    }
 
-    // Must be stakers
-    require(raffle.activeStake > 0, "Must be stakers");
+    function setBlockForged(uint32 slot) public {
+        fullFilled[slot] = true;
+    }
 
-    // If only one staker, just return it
-    if (operators.length == 1) return 0;
+    function getRaffleWinnerTest(uint32 slot, uint64 luckyNumber) public view returns (uint32 winner) {
+        // No negative era
+        uint32 era = slot / SLOTS_PER_ERA;
 
-    // Do the raffle
-    uint64 rnd = luckyNumber % raffle.activeStake;
-    winner = nodeRaffle(raffle.root, rnd);
-  }
+        // Only accept raffle for present and past eras
+        require (era <= currentEra()+1, "No access to not done raffles");
 
-  function getNode(uint32 idNode) public view returns (
-    uint32 era,
-    uint64 threashold,
-    uint64 increment,
-    bool isOpLeft,
-    uint32 left,
-    bool isOpRight,
-    uint32 right
-  ) {
-    IntermediateNode memory N = nodes[idNode];
-    return (
-      N.era,
-      N.threashold,
-      N.increment,
-      N.isOpLeft,
-      N.left,
-      N.isOpRight,
-      N.right
-    );
-  }
+        uint32 ri;
+        if (raffles[era].era == era) {
+            ri = era;
+        } else if (era > lastInitializedRaffle) {
+            ri = lastInitializedRaffle;
+        } else {
+            require(false, "Raffle not initialized for that era");
+        }
 
-  function getTreeLen() public view returns (uint256 era) {
-    return nodes.length;
-  }
+        Raffle storage raffle = raffles[ri];
 
-  function getRaffle(uint32 eraIndex) public view returns (
-    uint32 era,
-    uint32 root,
-    uint64 historicStake,
-    uint64 activeStake,
-    bytes8 seedRnd
+        // Must be stakers
+        require(raffle.activeStake > 0, "Must be stakers");
+
+        // If only one staker, just return it
+        if (operators.length == 1) return 0;
+
+        // Do the raffle
+        uint64 rnd = luckyNumber % raffle.activeStake;
+        winner = nodeRaffle(raffle.root, rnd);
+    }
+
+    function getNode(uint32 idNode) public view returns (
+        uint32 era,
+        uint64 threashold,
+        uint64 increment,
+        bool isOpLeft,
+        uint32 left,
+        bool isOpRight,
+        uint32 right
     ) {
-    Raffle memory raffleTest = raffles[eraIndex];
-    return (
-      raffleTest.era,
-      raffleTest.root,
-      raffleTest.historicStake,
-      raffleTest.activeStake,
-      raffleTest.seedRnd
-    );
-  }
+        IntermediateNode memory N = nodes[idNode];
+        return (
+          N.era,
+          N.threashold,
+          N.increment,
+          N.isOpLeft,
+          N.left,
+          N.isOpRight,
+          N.right
+        );
+    }
+
+    function getTreeLen() public view returns (uint256 era) {
+        return nodes.length;
+    }
+
+    function getRaffle(uint32 eraIndex) public view returns (
+        uint32 era,
+        uint32 root,
+        uint64 historicStake,
+        uint64 activeStake,
+        bytes8 seedRnd
+    ) {
+        Raffle memory raffleTest = raffles[eraIndex];
+        return (
+          raffleTest.era,
+          raffleTest.root,
+          raffleTest.historicStake,
+          raffleTest.activeStake,
+          raffleTest.seedRnd
+        );
+    }
+
+    function forgeCommitedBatch(
+        uint[2] calldata proofA,
+        uint[2][2] calldata proofB,
+        uint[2] calldata proofC,
+        uint[8] calldata input
+    ) external {
+        uint32 slot = currentSlot();
+        uint opId = getRaffleWinner(slot);
+        Operator storage op = operators[opId];
+        // Check that operator has commited data
+        require(commitSlot[slot].commited == true, 'There is no commited data');
+        // update previous hash commited by the operator
+        op.rndHash = commitSlot[slot].previousHash;
+        // clear commited data
+        commitSlot[slot].commited = false;
+        // one block has been forged in this slot
+        fullFilled[slot] = true;
+    }
 }

--- a/test/contracts/Rollup-PoS-integration.test.js
+++ b/test/contracts/Rollup-PoS-integration.test.js
@@ -3,200 +3,201 @@
 /* global artifacts */
 /* global contract */
 /* global web3 */
+/* global BigInt */
 
-const chai = require('chai');
-const RollupTree = require('../../rollup-utils/rollup-tree');
-const rollupUtils = require('../../rollup-utils/rollup-utils.js');
-const utils = require('../../rollup-utils/utils.js');
-const timeTravel = require('./helpers/timeTravel.js');
+const chai = require("chai");
+const RollupTree = require("../../rollup-utils/rollup-tree");
+const rollupUtils = require("../../rollup-utils/rollup-utils.js");
+const utils = require("../../rollup-utils/utils.js");
+const timeTravel = require("./helpers/timeTravel.js");
 
 const { expect } = chai;
-const poseidonUnit = require('../../node_modules/circomlib/src/poseidon_gencontract.js');
+const poseidonUnit = require("../../node_modules/circomlib/src/poseidon_gencontract.js");
 
-const TokenRollup = artifacts.require('../contracts/test/TokenRollup');
-const Verifier = artifacts.require('../contracts/test/VerifierHelper');
-const RollupPoS = artifacts.require('../contracts/RollupPoS');
-const Rollup = artifacts.require('../contracts/Rollup');
+const TokenRollup = artifacts.require("../contracts/test/TokenRollup");
+const Verifier = artifacts.require("../contracts/test/VerifierHelper");
+const RollupPoS = artifacts.require("../contracts/RollupPoS");
+const Rollup = artifacts.require("../contracts/Rollup");
 
 async function getEtherBalance(address) {
-  let balance = await web3.eth.getBalance(address);
-  balance = web3.utils.fromWei(balance, 'ether');
-  return Number(balance);
+    let balance = await web3.eth.getBalance(address);
+    balance = web3.utils.fromWei(balance, "ether");
+    return Number(balance);
 }
 
-contract('Rollup - RollupPoS', (accounts) => {
-  const {
-    0: owner,
-    1: id1,
-    2: withdrawAddress,
-    3: tokenList,
-    4: operator1,
-  } = accounts;
+contract("Rollup - RollupPoS", (accounts) => {
+    const {
+        0: owner,
+        1: id1,
+        2: withdrawAddress,
+        3: tokenList,
+        4: operator1,
+    } = accounts;
 
-  let balanceTree;
-  let fillingOnChainTest;
-  let minningOnChainTest;
+    let balanceTree;
+    let fillingOnChainTest;
+    let minningOnChainTest;
 
-  const tokenId = 0;
+    const tokenId = 0;
 
-  const hashChain = [];
-  const slotPerEra = 20;
-  const blocksPerSlot = 100;
-  const blockPerEra = slotPerEra * blocksPerSlot;
-  const amountToStake = 2;
+    const hashChain = [];
+    const slotPerEra = 20;
+    const blocksPerSlot = 100;
+    const blockPerEra = slotPerEra * blocksPerSlot;
+    const amountToStake = 2;
 
-  // BabyJub public key
-  const Ax = BigInt(30890499764467592830739030727222305800976141688008169211302);
-  const Ay = BigInt(19826930437678088398923647454327426275321075228766562806246);
+    // BabyJub public key
+    const Ax = BigInt(30890499764467592830739030727222305800976141688008169211302);
+    const Ay = BigInt(19826930437678088398923647454327426275321075228766562806246);
 
-  // tokenRollup initial amount
-  const tokenInitialAmount = 50;
-  const initialMsg = 'rollup';
+    // tokenRollup initial amount
+    const tokenInitialAmount = 50;
+    const initialMsg = "rollup";
 
-  let insPoseidonUnit;
-  let insTokenRollup;
-  let insRollupPoS;
-  let insRollup;
-  let insVerifier;
+    let insPoseidonUnit;
+    let insTokenRollup;
+    let insRollupPoS;
+    let insRollup;
+    let insVerifier;
 
-  before(async () => {
+    before(async () => {
     // Deploy poseidon
-    const C = new web3.eth.Contract(poseidonUnit.abi);
-    insPoseidonUnit = await C.deploy({ data: poseidonUnit.createCode() })
-      .send({ gas: 2500000, from: owner });
+        const C = new web3.eth.Contract(poseidonUnit.abi);
+        insPoseidonUnit = await C.deploy({ data: poseidonUnit.createCode() })
+            .send({ gas: 2500000, from: owner });
 
-    // Deploy TokenRollup
-    insTokenRollup = await TokenRollup.new(id1, tokenInitialAmount);
+        // Deploy TokenRollup
+        insTokenRollup = await TokenRollup.new(id1, tokenInitialAmount);
 
-    // Deploy Verifier
-    insVerifier = await Verifier.new();
+        // Deploy Verifier
+        insVerifier = await Verifier.new();
 
-    // Deploy Rollup test
-    insRollup = await Rollup.new(insVerifier.address, insPoseidonUnit._address, { from: owner });
+        // Deploy Rollup test
+        insRollup = await Rollup.new(insVerifier.address, insPoseidonUnit._address, { from: owner });
 
-    // Deploy Staker manager
-    insRollupPoS = await RollupPoS.new(insRollup.address);
+        // Deploy Staker manager
+        insRollupPoS = await RollupPoS.new(insRollup.address);
 
-    // Init balance tree
-    balanceTree = await RollupTree.newMemRollupTree();
+        // Init balance tree
+        balanceTree = await RollupTree.newMemRollupTree();
 
-    // Create hash chain for the operator
-    hashChain.push(web3.utils.keccak256(initialMsg));
-    for (let i = 1; i < 5; i++) {
-      hashChain.push(web3.utils.keccak256(hashChain[i - 1]));
-    }
-  });
+        // Create hash chain for the operator
+        hashChain.push(web3.utils.keccak256(initialMsg));
+        for (let i = 1; i < 5; i++) {
+            hashChain.push(web3.utils.keccak256(hashChain[i - 1]));
+        }
+    });
 
-  it('Initialization', async () => {
+    it("Initialization", async () => {
     // Add forge batch mechanism
-    await insRollup.loadForgeBatchMechanism(insRollupPoS.address, { from: owner });
-    // Add token to rollup token list
-    await insRollup.addToken(insTokenRollup.address,
-      { from: tokenList, value: web3.utils.toWei('1', 'ether') });
+        await insRollup.loadForgeBatchMechanism(insRollupPoS.address, { from: owner });
+        // Add token to rollup token list
+        await insRollup.addToken(insTokenRollup.address,
+            { from: tokenList, value: web3.utils.toWei("1", "ether") });
 
-    // Add operator to PoS
-    await insRollupPoS.addOperator(hashChain[4],
-      { from: operator1, value: web3.utils.toWei(amountToStake.toString(), 'ether') });
-  });
+        // Add operator to PoS
+        await insRollupPoS.addOperator(hashChain[4],
+            { from: operator1, value: web3.utils.toWei(amountToStake.toString(), "ether") });
+    });
 
-  it('Deposit', async () => {
-    const depositAmount = 10;
-    await insTokenRollup.approve(insRollup.address, depositAmount, { from: id1 });
+    it("Deposit", async () => {
+        const depositAmount = 10;
+        await insTokenRollup.approve(insRollup.address, depositAmount, { from: id1 });
 
-    const resDeposit = await insRollup.deposit(depositAmount, tokenId, [Ax.toString(), Ay.toString()],
-      withdrawAddress, { from: id1, value: web3.utils.toWei('1', 'ether') });
+        const resDeposit = await insRollup.deposit(depositAmount, tokenId, [Ax.toString(), Ay.toString()],
+            withdrawAddress, { from: id1, value: web3.utils.toWei("1", "ether") });
 
-    // Get event 'Deposit' data
-    const resId = BigInt(resDeposit.logs[0].args.idBalanceTree);
-    const resDepositAmount = BigInt(resDeposit.logs[0].args.depositAmount);
-    const resTokenId = BigInt(resDeposit.logs[0].args.tokenId);
-    const resAx = BigInt(resDeposit.logs[0].args.Ax);
-    const resAy = BigInt(resDeposit.logs[0].args.Ay);
-    const resWithdrawAddress = BigInt(resDeposit.logs[0].args.withdrawAddress);
+        // Get event 'Deposit' data
+        const resId = BigInt(resDeposit.logs[0].args.idBalanceTree);
+        const resDepositAmount = BigInt(resDeposit.logs[0].args.depositAmount);
+        const resTokenId = BigInt(resDeposit.logs[0].args.tokenId);
+        const resAx = BigInt(resDeposit.logs[0].args.Ax);
+        const resAy = BigInt(resDeposit.logs[0].args.Ay);
+        const resWithdrawAddress = BigInt(resDeposit.logs[0].args.withdrawAddress);
 
-    // create balance tree and add leaf
-    balanceTree = await RollupTree.newMemRollupTree();
-    await balanceTree.addId(resId, resDepositAmount,
-      resTokenId, resAx, resAy, resWithdrawAddress, BigInt(0));
+        // create balance tree and add leaf
+        balanceTree = await RollupTree.newMemRollupTree();
+        await balanceTree.addId(resId, resDepositAmount,
+            resTokenId, resAx, resAy, resWithdrawAddress, BigInt(0));
 
-    // Calculate Deposit hash given the events triggered
-    const calcFilling = rollupUtils.hashDeposit(resId, resDepositAmount, resTokenId, resAx,
-      resAy, resWithdrawAddress, BigInt(0));
+        // Calculate Deposit hash given the events triggered
+        const calcFilling = rollupUtils.hashDeposit(resId, resDepositAmount, resTokenId, resAx,
+            resAy, resWithdrawAddress, BigInt(0));
 
-    // calculate filling on chain hash by the operator
-    let fillingOnChainTxsHash = BigInt(0);
-    fillingOnChainTxsHash = utils.hash([fillingOnChainTxsHash, calcFilling]);
+        // calculate filling on chain hash by the operator
+        let fillingOnChainTxsHash = BigInt(0);
+        fillingOnChainTxsHash = utils.hash([fillingOnChainTxsHash, calcFilling]);
 
-    // Update on-chain hashes
-    fillingOnChainTest = fillingOnChainTxsHash.toString();
-    minningOnChainTest = 0;
-  });
+        // Update on-chain hashes
+        fillingOnChainTest = fillingOnChainTxsHash.toString();
+        minningOnChainTest = 0;
+    });
 
-  it('Forge batches by operator PoS', async () => {
-    const proofA = ['0', '0'];
-    const proofB = [['0', '0'], ['0', '0']];
-    const proofC = ['0', '0'];
-    // move forward block number to allow the operator to forge a batch
-    let currentBlock = await web3.eth.getBlockNumber();
-    const genesisBlock = await insRollupPoS.genesisBlock();
-    await timeTravel.addBlocks(genesisBlock - currentBlock);
-    currentBlock = await web3.eth.getBlockNumber();
-    await timeTravel.addBlocks(blockPerEra);
-    currentBlock = await web3.eth.getBlockNumber();
-    await timeTravel.addBlocks(blockPerEra);
-    currentBlock = await web3.eth.getBlockNumber();
+    it("Forge batches by operator PoS", async () => {
+        const proofA = ["0", "0"];
+        const proofB = [["0", "0"], ["0", "0"]];
+        const proofC = ["0", "0"];
+        // move forward block number to allow the operator to forge a batch
+        let currentBlock = await web3.eth.getBlockNumber();
+        const genesisBlock = await insRollupPoS.genesisBlock();
+        await timeTravel.addBlocks(genesisBlock - currentBlock);
+        currentBlock = await web3.eth.getBlockNumber();
+        await timeTravel.addBlocks(blockPerEra);
+        currentBlock = await web3.eth.getBlockNumber();
+        await timeTravel.addBlocks(blockPerEra);
+        currentBlock = await web3.eth.getBlockNumber();
 
-    // build inputs
-    const oldStateRoot = BigInt(0).toString();
-    let newStateRoot = BigInt(0).toString();
-    const newExitRoot = BigInt(0).toString();
-    const onChainHash = BigInt(0).toString();
-    const feePlan = [BigInt(0).toString(), BigInt(0).toString()];
-    const nTxPerToken = BigInt(0).toString();
+        // build inputs
+        const oldStateRoot = BigInt(0).toString();
+        let newStateRoot = BigInt(0).toString();
+        const newExitRoot = BigInt(0).toString();
+        const onChainHash = BigInt(0).toString();
+        const feePlan = [BigInt(0).toString(), BigInt(0).toString()];
+        const nTxPerToken = BigInt(0).toString();
 
-    const offChainTx = rollupUtils.createOffChainTx(1);
-    const offChainHash = offChainTx.hashOffChain.toString();
-    const compressedTxs = offChainTx.bytesTx;
+        const offChainTx = rollupUtils.createOffChainTx(1);
+        const offChainHash = offChainTx.hashOffChain.toString();
+        const compressedTxs = offChainTx.bytesTx;
 
-    let inputs = [
-      oldStateRoot,
-      newStateRoot,
-      newExitRoot,
-      onChainHash,
-      offChainHash,
-      feePlan[0],
-      feePlan[1],
-      nTxPerToken,
-    ];
+        let inputs = [
+            oldStateRoot,
+            newStateRoot,
+            newExitRoot,
+            onChainHash,
+            offChainHash,
+            feePlan[0],
+            feePlan[1],
+            nTxPerToken,
+        ];
 
-    // Check balances
-    const balOpBeforeForge = await getEtherBalance(operator1);
-    // Forge genesis batch by operator 1
-    await insRollupPoS.forgeBatchPoS(hashChain[3], proofA, proofB,
-      proofC, inputs, compressedTxs, { from: operator1 });
-    // Update on-chain hashes
-    minningOnChainTest = fillingOnChainTest;
-    fillingOnChainTest = BigInt(0).toString();
+        // Check balances
+        const balOpBeforeForge = await getEtherBalance(operator1);
+        // Forge genesis batch by operator 1
+        await insRollupPoS.forgeBatchPoS(hashChain[3], proofA, proofB,
+            proofC, inputs, compressedTxs, { from: operator1 });
+        // Update on-chain hashes
+        minningOnChainTest = fillingOnChainTest;
+        fillingOnChainTest = BigInt(0).toString();
 
-    // build inputs
-    newStateRoot = await balanceTree.getRoot();
-    inputs = [
-      oldStateRoot,
-      newStateRoot.toString(),
-      newExitRoot,
-      minningOnChainTest,
-      offChainHash,
-      feePlan[0],
-      feePlan[1],
-      nTxPerToken,
-    ];
+        // build inputs
+        newStateRoot = await balanceTree.getRoot();
+        inputs = [
+            oldStateRoot,
+            newStateRoot.toString(),
+            newExitRoot,
+            minningOnChainTest,
+            offChainHash,
+            feePlan[0],
+            feePlan[1],
+            nTxPerToken,
+        ];
 
-    // Forge batch by operator 1
-    await insRollupPoS.forgeBatchPoS(hashChain[2], proofA, proofB,
-      proofC, inputs, compressedTxs, { from: operator1 });
+        // Forge batch by operator 1
+        await insRollupPoS.forgeBatchPoS(hashChain[2], proofA, proofB,
+            proofC, inputs, compressedTxs, { from: operator1 });
 
-    // Check balances
-    const balOpAfterForge = await getEtherBalance(operator1);
-    expect(Math.ceil(balOpBeforeForge) + 1).to.be.equal(Math.ceil(balOpAfterForge));
-  });
+        // Check balances
+        const balOpAfterForge = await getEtherBalance(operator1);
+        expect(Math.ceil(balOpBeforeForge) + 1).to.be.equal(Math.ceil(balOpAfterForge));
+    });
 });

--- a/test/contracts/Rollup-onChain.test.js
+++ b/test/contracts/Rollup-onChain.test.js
@@ -3,101 +3,101 @@
 /* global contract */
 /* global web3 */
 
-const chai = require('chai');
-const RollupTree = require('../../rollup-utils/rollup-tree');
-const rollupUtils = require('../../rollup-utils/rollup-utils.js');
-const utils = require('../../rollup-utils/utils.js');
+const chai = require("chai");
+const RollupTree = require("../../rollup-utils/rollup-tree");
+const rollupUtils = require("../../rollup-utils/rollup-utils.js");
+const utils = require("../../rollup-utils/utils.js");
 
 const { expect } = chai;
-const poseidonUnit = require('../../node_modules/circomlib/src/poseidon_gencontract.js');
+const poseidonUnit = require("../../node_modules/circomlib/src/poseidon_gencontract.js");
 
-const TokenRollup = artifacts.require('../contracts/test/TokenRollup');
-const Verifier = artifacts.require('../contracts/test/VerifierHelper');
-const StakerManager = artifacts.require('../contracts/RollupPoS');
-const RollupTest = artifacts.require('../contracts/test/RollupTest');
+const TokenRollup = artifacts.require("../contracts/test/TokenRollup");
+const Verifier = artifacts.require("../contracts/test/VerifierHelper");
+const StakerManager = artifacts.require("../contracts/RollupPoS");
+const RollupTest = artifacts.require("../contracts/test/RollupTest");
 
-contract('Rollup', (accounts) => {
-  let balanceTree;
-  let fillingOnChainTest;
-  let minningOnChainTest;
+contract("Rollup", (accounts) => {
+    let balanceTree;
+    let fillingOnChainTest;
+    let minningOnChainTest;
 
-  let insPoseidonUnit;
-  let insTokenRollup;
-  let insStakerManager;
-  let insRollupTest;
-  let insVerifier;
+    let insPoseidonUnit;
+    let insTokenRollup;
+    let insStakerManager;
+    let insRollupTest;
+    let insVerifier;
 
-  // BabyJub public key
-  const Ax = BigInt(30890499764467592830739030727222305800976141688008169211302);
-  const Ay = BigInt(19826930437678088398923647454327426275321075228766562806246);
+    // BabyJub public key
+    const Ax = BigInt(30890499764467592830739030727222305800976141688008169211302);
+    const Ay = BigInt(19826930437678088398923647454327426275321075228766562806246);
 
-  // tokenRollup initial amount
-  const tokenInitialAmount = 100;
+    // tokenRollup initial amount
+    const tokenInitialAmount = 100;
 
-  const {
-    0: owner,
-    1: id1,
-    2: withdrawAddress,
-    3: tokenList,
-    4: beneficiary,
-    5: onAddress,
-  } = accounts;
+    const {
+        0: owner,
+        1: id1,
+        2: withdrawAddress,
+        3: tokenList,
+        4: beneficiary,
+        5: onAddress,
+    } = accounts;
 
-  before(async () => {
+    before(async () => {
     // Deploy poseidon
-    const C = new web3.eth.Contract(poseidonUnit.abi);
-    insPoseidonUnit = await C.deploy({ data: poseidonUnit.createCode() })
-      .send({ gas: 2500000, from: owner });
+        const C = new web3.eth.Contract(poseidonUnit.abi);
+        insPoseidonUnit = await C.deploy({ data: poseidonUnit.createCode() })
+            .send({ gas: 2500000, from: owner });
 
-    // Deploy TokenRollup
-    insTokenRollup = await TokenRollup.new(id1, tokenInitialAmount);
+        // Deploy TokenRollup
+        insTokenRollup = await TokenRollup.new(id1, tokenInitialAmount);
 
-    // Deploy Verifier
-    insVerifier = await Verifier.new();
+        // Deploy Verifier
+        insVerifier = await Verifier.new();
 
-    // Deploy Rollup test
-    insRollupTest = await RollupTest.new(insVerifier.address, insPoseidonUnit._address);
+        // Deploy Rollup test
+        insRollupTest = await RollupTest.new(insVerifier.address, insPoseidonUnit._address);
 
-    // Deploy Staker manager
-    insStakerManager = await StakerManager.new(insRollupTest.address);
-  });
+        // Deploy Staker manager
+        insStakerManager = await StakerManager.new(insRollupTest.address);
+    });
 
-  it('Load forge batch mechanism', async () => {
-    await insRollupTest.loadForgeBatchMechanism(insStakerManager.address);
-    try {
-      await insRollupTest.loadForgeBatchMechanism(insStakerManager.address, { from: id1 });
-    } catch (error) {
-      expect((error.message).includes('caller is not the owner')).to.be.equal(true);
-    }
-  });
+    it("Load forge batch mechanism", async () => {
+        await insRollupTest.loadForgeBatchMechanism(insStakerManager.address);
+        try {
+            await insRollupTest.loadForgeBatchMechanism(insStakerManager.address, { from: id1 });
+        } catch (error) {
+            expect((error.message).includes("caller is not the owner")).to.be.equal(true);
+        }
+    });
 
-  it('Distribute token rollup', async () => {
-    await insTokenRollup.transfer(onAddress, 50, { from: id1 });
-  });
+    it("Distribute token rollup", async () => {
+        await insTokenRollup.transfer(onAddress, 50, { from: id1 });
+    });
 
-  it('Rollup token listing', async () => {
+    it("Rollup token listing", async () => {
     // Check balances token
-    const resOwner = await insTokenRollup.balanceOf(owner);
-    const resId1 = await insTokenRollup.balanceOf(id1);
-    expect(resOwner.toString()).to.be.equal('0');
-    expect(resId1.toString()).to.be.equal('50');
+        const resOwner = await insTokenRollup.balanceOf(owner);
+        const resId1 = await insTokenRollup.balanceOf(id1);
+        expect(resOwner.toString()).to.be.equal("0");
+        expect(resId1.toString()).to.be.equal("50");
 
-    // Add token to rollup token list
-    const resAddToken = await insRollupTest.addToken(insTokenRollup.address,
-      { from: tokenList, value: web3.utils.toWei('1', 'ether') });
+        // Add token to rollup token list
+        const resAddToken = await insRollupTest.addToken(insTokenRollup.address,
+            { from: tokenList, value: web3.utils.toWei("1", "ether") });
 
-    expect(resAddToken.logs[0].event).to.be.equal('AddToken');
-    expect(resAddToken.logs[0].args.tokenAddress).to.be.equal(insTokenRollup.address);
-    expect(resAddToken.logs[0].args.tokenId.toString()).to.be.equal('0');
-  });
+        expect(resAddToken.logs[0].event).to.be.equal("AddToken");
+        expect(resAddToken.logs[0].args.tokenAddress).to.be.equal(insTokenRollup.address);
+        expect(resAddToken.logs[0].args.tokenId.toString()).to.be.equal("0");
+    });
 
-  it('Check token address', async () => {
+    it("Check token address", async () => {
     // Check token address
-    const resTokenAddress = await insRollupTest.getTokenAddress(0);
-    expect(resTokenAddress).to.be.equal(insTokenRollup.address);
-  });
+        const resTokenAddress = await insRollupTest.getTokenAddress(0);
+        expect(resTokenAddress).to.be.equal(insTokenRollup.address);
+    });
 
-  it('Deposit balance tree', async () => {
+    it("Deposit balance tree", async () => {
     // Steps:
     // - Transaction to deposit 'TokenRollup' from 'id1' to 'rollup smart contract'(owner)
     // - Check 'tokenRollup' balances
@@ -105,310 +105,310 @@ contract('Rollup', (accounts) => {
     // - Add leaf to balance tree
     // - Check 'filling on-chain' hash
 
-    const depositAmount = 10;
-    const tokenId = 0;
+        const depositAmount = 10;
+        const tokenId = 0;
 
-    const resApprove = await insTokenRollup.approve(insRollupTest.address, depositAmount, { from: id1 });
-    expect(resApprove.logs[0].event).to.be.equal('Approval');
+        const resApprove = await insTokenRollup.approve(insRollupTest.address, depositAmount, { from: id1 });
+        expect(resApprove.logs[0].event).to.be.equal("Approval");
 
-    const resDeposit = await insRollupTest.deposit(depositAmount, tokenId, [Ax.toString(), Ay.toString()],
-      withdrawAddress, { from: id1, value: web3.utils.toWei('1', 'ether') });
-    expect(resDeposit.logs[0].event).to.be.equal('Deposit');
+        const resDeposit = await insRollupTest.deposit(depositAmount, tokenId, [Ax.toString(), Ay.toString()],
+            withdrawAddress, { from: id1, value: web3.utils.toWei("1", "ether") });
+        expect(resDeposit.logs[0].event).to.be.equal("Deposit");
 
-    // Check token balances for id1 and rollup smart contract
-    const resRollup = await insTokenRollup.balanceOf(insRollupTest.address);
-    const resId1 = await insTokenRollup.balanceOf(id1);
-    expect(resRollup.toString()).to.be.equal('10');
-    expect(resId1.toString()).to.be.equal('40');
+        // Check token balances for id1 and rollup smart contract
+        const resRollup = await insTokenRollup.balanceOf(insRollupTest.address);
+        const resId1 = await insTokenRollup.balanceOf(id1);
+        expect(resRollup.toString()).to.be.equal("10");
+        expect(resId1.toString()).to.be.equal("40");
 
-    // Get event 'Deposit' data
-    const resId = BigInt(resDeposit.logs[0].args.idBalanceTree);
-    const resDepositAmount = BigInt(resDeposit.logs[0].args.depositAmount);
-    const resTokenId = BigInt(resDeposit.logs[0].args.tokenId);
-    const resAx = BigInt(resDeposit.logs[0].args.Ax);
-    const resAy = BigInt(resDeposit.logs[0].args.Ay);
-    const resWithdrawAddress = BigInt(resDeposit.logs[0].args.withdrawAddress);
+        // Get event 'Deposit' data
+        const resId = BigInt(resDeposit.logs[0].args.idBalanceTree);
+        const resDepositAmount = BigInt(resDeposit.logs[0].args.depositAmount);
+        const resTokenId = BigInt(resDeposit.logs[0].args.tokenId);
+        const resAx = BigInt(resDeposit.logs[0].args.Ax);
+        const resAy = BigInt(resDeposit.logs[0].args.Ay);
+        const resWithdrawAddress = BigInt(resDeposit.logs[0].args.withdrawAddress);
 
-    // create balance tree and add leaf
-    balanceTree = await RollupTree.newMemRollupTree();
-    await balanceTree.addId(resId, resDepositAmount,
-      resTokenId, resAx, resAy, resWithdrawAddress, BigInt(0));
+        // create balance tree and add leaf
+        balanceTree = await RollupTree.newMemRollupTree();
+        await balanceTree.addId(resId, resDepositAmount,
+            resTokenId, resAx, resAy, resWithdrawAddress, BigInt(0));
 
-    // Calculate Deposit hash given the events triggered
-    const calcFilling = rollupUtils.hashDeposit(resId, resDepositAmount, resTokenId, resAx,
-      resAy, resWithdrawAddress, BigInt(0));
+        // Calculate Deposit hash given the events triggered
+        const calcFilling = rollupUtils.hashDeposit(resId, resDepositAmount, resTokenId, resAx,
+            resAy, resWithdrawAddress, BigInt(0));
 
-    // calculate filling on chain hash by the operator
-    let fillingOnChainTxsHash = BigInt(0);
-    fillingOnChainTxsHash = utils.hash([fillingOnChainTxsHash, calcFilling]);
+        // calculate filling on chain hash by the operator
+        let fillingOnChainTxsHash = BigInt(0);
+        fillingOnChainTxsHash = utils.hash([fillingOnChainTxsHash, calcFilling]);
 
-    const resFillingTest = await insRollupTest.getFillingOnChainTxsHash();
-    expect(fillingOnChainTxsHash.toString()).to.be.equal(BigInt(resFillingTest).toString());
+        const resFillingTest = await insRollupTest.getFillingOnChainTxsHash();
+        expect(fillingOnChainTxsHash.toString()).to.be.equal(BigInt(resFillingTest).toString());
 
-    // Update on-chain hashes
-    fillingOnChainTest = BigInt(resFillingTest).toString();
-    minningOnChainTest = 0;
-  });
+        // Update on-chain hashes
+        fillingOnChainTest = BigInt(resFillingTest).toString();
+        minningOnChainTest = 0;
+    });
 
-  it('Forge genesis batch', async () => {
+    it("Forge genesis batch", async () => {
     // Forge first batch implies not balance tree state change at all
     // it forces the next batch to incorporate on-chain transactions
     // i.e. transaction that has been done in previous step
-    const oldStateRoot = BigInt(0).toString();
-    const newStateRoot = BigInt(0).toString();
-    const newExitRoot = BigInt(0).toString();
-    const onChainHash = BigInt(0).toString();
-    const feePlan = [BigInt(0).toString(), BigInt(0).toString()];
+        const oldStateRoot = BigInt(0).toString();
+        const newStateRoot = BigInt(0).toString();
+        const newExitRoot = BigInt(0).toString();
+        const onChainHash = BigInt(0).toString();
+        const feePlan = [BigInt(0).toString(), BigInt(0).toString()];
 
-    const offChainTx = rollupUtils.createOffChainTx(1);
-    const offChainHash = offChainTx.hashOffChain.toString();
-    const compressedTxs = offChainTx.bytesTx;
+        const offChainTx = rollupUtils.createOffChainTx(1);
+        const offChainHash = offChainTx.hashOffChain.toString();
+        const compressedTxs = offChainTx.bytesTx;
 
-    const nTxPerToken = BigInt(0).toString();
+        const nTxPerToken = BigInt(0).toString();
 
-    const resForge = await insRollupTest.forgeBatchTest(oldStateRoot, newStateRoot, newExitRoot,
-      onChainHash, feePlan, compressedTxs, offChainHash, nTxPerToken, beneficiary);
+        const resForge = await insRollupTest.forgeBatchTest(oldStateRoot, newStateRoot, newExitRoot,
+            onChainHash, feePlan, compressedTxs, offChainHash, nTxPerToken, beneficiary);
 
-    expect(resForge.logs[0].event).to.be.equal('ForgeBatch');
-    expect(resForge.logs[0].args.batchNumber.toString()).to.be.equal('0');
-    expect(resForge.logs[0].args.offChainTx).to.be.equal(compressedTxs);
+        expect(resForge.logs[0].event).to.be.equal("ForgeBatch");
+        expect(resForge.logs[0].args.batchNumber.toString()).to.be.equal("0");
+        expect(resForge.logs[0].args.offChainTx).to.be.equal(compressedTxs);
 
-    // Update on-chain hashes
-    minningOnChainTest = fillingOnChainTest;
-    fillingOnChainTest = BigInt(0).toString();
+        // Update on-chain hashes
+        minningOnChainTest = fillingOnChainTest;
+        fillingOnChainTest = BigInt(0).toString();
 
-    // Check minning / filling on-chain hash
-    const resMinning = await insRollupTest.getMinningOnChainTxsHash();
-    const resFilling = await insRollupTest.getFillingOnChainTxsHash();
+        // Check minning / filling on-chain hash
+        const resMinning = await insRollupTest.getMinningOnChainTxsHash();
+        const resFilling = await insRollupTest.getFillingOnChainTxsHash();
 
-    expect(minningOnChainTest).to.be.equal(BigInt(resMinning).toString());
-    expect(fillingOnChainTest).to.be.equal(BigInt(resFilling).toString());
+        expect(minningOnChainTest).to.be.equal(BigInt(resMinning).toString());
+        expect(fillingOnChainTest).to.be.equal(BigInt(resFilling).toString());
 
-    // Check last state root forged
-    const resState = await insRollupTest.getStateRoot('0');
-    expect(BigInt(resState).toString()).to.be.equal('0');
-  });
+        // Check last state root forged
+        const resState = await insRollupTest.getStateRoot("0");
+        expect(BigInt(resState).toString()).to.be.equal("0");
+    });
 
-  it('Forge batch deposit', async () => {
+    it("Forge batch deposit", async () => {
     // Operator must introduce a new leaf into the balance tree which
     // comes from the first deposit on-chain transaction
     // It implies that the balance tree has now one leaf, therefore its
     // root must be updated
 
-    const oldStateRoot = BigInt(0).toString();
-    let newStateRoot = await balanceTree.getRoot();
-    newStateRoot = newStateRoot.toString();
-    const newExitRoot = BigInt(0).toString(); // Assume no off-chain tx
-    const onChainHash = minningOnChainTest;
-    const feePlan = [BigInt(0).toString(), BigInt(0).toString()];
+        const oldStateRoot = BigInt(0).toString();
+        let newStateRoot = await balanceTree.getRoot();
+        newStateRoot = newStateRoot.toString();
+        const newExitRoot = BigInt(0).toString(); // Assume no off-chain tx
+        const onChainHash = minningOnChainTest;
+        const feePlan = [BigInt(0).toString(), BigInt(0).toString()];
 
-    const offChainTx = rollupUtils.createOffChainTx(1);
-    const offChainHash = offChainTx.hashOffChain.toString();
-    const compressedTxs = offChainTx.bytesTx;
+        const offChainTx = rollupUtils.createOffChainTx(1);
+        const offChainHash = offChainTx.hashOffChain.toString();
+        const compressedTxs = offChainTx.bytesTx;
 
-    const nTxPerToken = BigInt(0).toString();
+        const nTxPerToken = BigInt(0).toString();
 
-    const resForge = await insRollupTest.forgeBatchTest(oldStateRoot, newStateRoot, newExitRoot,
-      onChainHash, feePlan, compressedTxs, offChainHash, nTxPerToken, beneficiary);
+        const resForge = await insRollupTest.forgeBatchTest(oldStateRoot, newStateRoot, newExitRoot,
+            onChainHash, feePlan, compressedTxs, offChainHash, nTxPerToken, beneficiary);
 
-    expect(resForge.logs[0].event).to.be.equal('ForgeBatch');
-    expect(resForge.logs[0].args.batchNumber.toString()).to.be.equal('1');
-    expect(resForge.logs[0].args.offChainTx).to.be.equal(compressedTxs);
+        expect(resForge.logs[0].event).to.be.equal("ForgeBatch");
+        expect(resForge.logs[0].args.batchNumber.toString()).to.be.equal("1");
+        expect(resForge.logs[0].args.offChainTx).to.be.equal(compressedTxs);
 
-    // Update on-chain hashes
-    minningOnChainTest = BigInt(0).toString();
-    fillingOnChainTest = BigInt(0).toString();
+        // Update on-chain hashes
+        minningOnChainTest = BigInt(0).toString();
+        fillingOnChainTest = BigInt(0).toString();
 
-    // Check minning / filling on-chain hash
-    const resMinning = await insRollupTest.getMinningOnChainTxsHash();
-    const resFilling = await insRollupTest.getFillingOnChainTxsHash();
+        // Check minning / filling on-chain hash
+        const resMinning = await insRollupTest.getMinningOnChainTxsHash();
+        const resFilling = await insRollupTest.getFillingOnChainTxsHash();
 
-    expect(minningOnChainTest).to.be.equal(BigInt(resMinning).toString());
-    expect(fillingOnChainTest).to.be.equal(BigInt(resFilling).toString());
+        expect(minningOnChainTest).to.be.equal(BigInt(resMinning).toString());
+        expect(fillingOnChainTest).to.be.equal(BigInt(resFilling).toString());
 
-    // Check last state root forged
-    const resState = await insRollupTest.getStateRoot('1');
-    expect(BigInt(resState).toString()).to.be.equal(newStateRoot);
-  });
+        // Check last state root forged
+        const resState = await insRollupTest.getStateRoot("1");
+        expect(BigInt(resState).toString()).to.be.equal(newStateRoot);
+    });
 
-  it('Deposit on top', async () => {
+    it("Deposit on top", async () => {
     // Deposit on top on-chain transaction is submitted
     // It will be forged two blocks forward
     // We will check balances of all address involved
     // Approve rollup smart contract to spend 'onAddress' tokens
 
-    // To make a deposit on top we have to prove:
-    // - An id exist on the balance tree with a given tokenId in any batch
-    // - in order to do so, we have to submit the merkle tree proof
+        // To make a deposit on top we have to prove:
+        // - An id exist on the balance tree with a given tokenId in any batch
+        // - in order to do so, we have to submit the merkle tree proof
 
-    // get merkle tree proof from balance tree
-    const id = BigInt(1);
-    const proofId = await balanceTree.getIdInfo(id);
-    const siblingsId = utils.arrayBigIntToArrayStr(proofId.siblings);
+        // get merkle tree proof from balance tree
+        const id = BigInt(1);
+        const proofId = await balanceTree.getIdInfo(id);
+        const siblingsId = utils.arrayBigIntToArrayStr(proofId.siblings);
 
-    const stateRoot = BigInt('1');
-    const amountToDeposit = BigInt('25');
+        const stateRoot = BigInt("1");
+        const amountToDeposit = BigInt("25");
 
-    const resApprove = await insTokenRollup.approve(insRollupTest.address, amountToDeposit.toString(),
-      { from: onAddress });
-    expect(resApprove.logs[0].event).to.be.equal('Approval');
+        const resApprove = await insTokenRollup.approve(insRollupTest.address, amountToDeposit.toString(),
+            { from: onAddress });
+        expect(resApprove.logs[0].event).to.be.equal("Approval");
 
 
-    const resDepositOnTop = await insRollupTest.depositOnTop(
-      id.toString(),
-      proofId.foundObject.balance.toString(),
-      proofId.foundObject.tokenId.toString(),
-      `0x${proofId.foundObject.withdrawAddress.toString('16')}`,
-      proofId.foundObject.nonce.toString(),
-      [proofId.foundObject.Ax.toString(), proofId.foundObject.Ay.toString()],
-      siblingsId,
-      stateRoot.toString(),
-      amountToDeposit.toString(),
-      { from: onAddress, value: web3.utils.toWei('1', 'ether') },
-    );
+        const resDepositOnTop = await insRollupTest.depositOnTop(
+            id.toString(),
+            proofId.foundObject.balance.toString(),
+            proofId.foundObject.tokenId.toString(),
+            `0x${proofId.foundObject.withdrawAddress.toString("16")}`,
+            proofId.foundObject.nonce.toString(),
+            [proofId.foundObject.Ax.toString(), proofId.foundObject.Ay.toString()],
+            siblingsId,
+            stateRoot.toString(),
+            amountToDeposit.toString(),
+            { from: onAddress, value: web3.utils.toWei("1", "ether") },
+        );
 
-    expect(resDepositOnTop.logs[0].event).to.be.equal('DepositOnTop');
+        expect(resDepositOnTop.logs[0].event).to.be.equal("DepositOnTop");
 
-    // Check balances tokens
-    const resRollup = await insTokenRollup.balanceOf(insRollupTest.address);
-    const resId1 = await insTokenRollup.balanceOf(id1);
-    const resOnTop = await insTokenRollup.balanceOf(onAddress);
+        // Check balances tokens
+        const resRollup = await insTokenRollup.balanceOf(insRollupTest.address);
+        const resId1 = await insTokenRollup.balanceOf(id1);
+        const resOnTop = await insTokenRollup.balanceOf(onAddress);
 
-    expect(resRollup.toString()).to.be.equal('35');
-    expect(resId1.toString()).to.be.equal('40');
-    expect(resOnTop.toString()).to.be.equal('25');
-  });
+        expect(resRollup.toString()).to.be.equal("35");
+        expect(resId1.toString()).to.be.equal("40");
+        expect(resOnTop.toString()).to.be.equal("25");
+    });
 
-  it('Forge batches deposit on top', async () => {
+    it("Forge batches deposit on top", async () => {
     // Forge first batch implies not balance tree state change at all
     // it only updates fillingOnChainTx to force insert previous 'depostOnTop' Tx
     // we update second batch including deposit on top on blance tree
-    let lastIndexStateRoot = await insRollupTest.getStateDepth();
-    lastIndexStateRoot = BigInt(lastIndexStateRoot) - BigInt(1);
-    const oldStateRoot = await insRollupTest.getStateRoot(lastIndexStateRoot.toString());
-    let newStateRoot = oldStateRoot;
-    const newExitRoot = BigInt(0).toString();
-    const onChainHash = BigInt(0).toString();
-    const feePlan = [BigInt(0).toString(), BigInt(0).toString()];
+        let lastIndexStateRoot = await insRollupTest.getStateDepth();
+        lastIndexStateRoot = BigInt(lastIndexStateRoot) - BigInt(1);
+        const oldStateRoot = await insRollupTest.getStateRoot(lastIndexStateRoot.toString());
+        let newStateRoot = oldStateRoot;
+        const newExitRoot = BigInt(0).toString();
+        const onChainHash = BigInt(0).toString();
+        const feePlan = [BigInt(0).toString(), BigInt(0).toString()];
 
-    const offChainTx = rollupUtils.createOffChainTx(1);
-    const offChainHash = offChainTx.hashOffChain.toString();
-    const compressedTxs = offChainTx.bytesTx;
+        const offChainTx = rollupUtils.createOffChainTx(1);
+        const offChainHash = offChainTx.hashOffChain.toString();
+        const compressedTxs = offChainTx.bytesTx;
 
-    const nTxPerToken = BigInt(0).toString();
+        const nTxPerToken = BigInt(0).toString();
 
-    const resForge = await insRollupTest.forgeBatchTest(oldStateRoot, newStateRoot, newExitRoot,
-      onChainHash, feePlan, compressedTxs, offChainHash, nTxPerToken, beneficiary);
+        const resForge = await insRollupTest.forgeBatchTest(oldStateRoot, newStateRoot, newExitRoot,
+            onChainHash, feePlan, compressedTxs, offChainHash, nTxPerToken, beneficiary);
 
-    expect(resForge.logs[0].event).to.be.equal('ForgeBatch');
-    expect(resForge.logs[0].args.batchNumber.toString()).to.be.equal('2');
-    expect(resForge.logs[0].args.offChainTx).to.be.equal(compressedTxs);
+        expect(resForge.logs[0].event).to.be.equal("ForgeBatch");
+        expect(resForge.logs[0].args.batchNumber.toString()).to.be.equal("2");
+        expect(resForge.logs[0].args.offChainTx).to.be.equal(compressedTxs);
 
-    // Update on-chain hashes
-    minningOnChainTest = await insRollupTest.getMinningOnChainTxsHash();
-    fillingOnChainTest = BigInt(0).toString();
+        // Update on-chain hashes
+        minningOnChainTest = await insRollupTest.getMinningOnChainTxsHash();
+        fillingOnChainTest = BigInt(0).toString();
 
-    // Calculate fillingOnChainHash
-    let resLeafValue = await balanceTree.getIdInfo(BigInt(1));
-    resLeafValue = resLeafValue.foundValue.toString();
-    // calculate filling on chain hash by the operator
-    let onChainHashOp = BigInt(0);
-    onChainHashOp = utils.hash([onChainHash, resLeafValue]);
+        // Calculate fillingOnChainHash
+        let resLeafValue = await balanceTree.getIdInfo(BigInt(1));
+        resLeafValue = resLeafValue.foundValue.toString();
+        // calculate filling on chain hash by the operator
+        let onChainHashOp = BigInt(0);
+        onChainHashOp = utils.hash([onChainHash, resLeafValue]);
 
-    expect(onChainHashOp.toString()).to.be.equal(BigInt(minningOnChainTest).toString());
+        expect(onChainHashOp.toString()).to.be.equal(BigInt(minningOnChainTest).toString());
 
-    // Update balance tree with 'deposit on top' transaction
-    await balanceTree.updateId(BigInt(1), BigInt(35));
-    newStateRoot = await balanceTree.getRoot();
-    newStateRoot = newStateRoot.toString();
-    const resForge2 = await insRollupTest.forgeBatchTest(oldStateRoot, newStateRoot,
-      newExitRoot, onChainHashOp.toString(), feePlan, compressedTxs, offChainHash, nTxPerToken, beneficiary);
+        // Update balance tree with 'deposit on top' transaction
+        await balanceTree.updateId(BigInt(1), BigInt(35));
+        newStateRoot = await balanceTree.getRoot();
+        newStateRoot = newStateRoot.toString();
+        const resForge2 = await insRollupTest.forgeBatchTest(oldStateRoot, newStateRoot,
+            newExitRoot, onChainHashOp.toString(), feePlan, compressedTxs, offChainHash, nTxPerToken, beneficiary);
 
-    expect(resForge2.logs[0].event).to.be.equal('ForgeBatch');
-    expect(resForge2.logs[0].args.batchNumber.toString()).to.be.equal('3');
-  });
+        expect(resForge2.logs[0].event).to.be.equal("ForgeBatch");
+        expect(resForge2.logs[0].args.batchNumber.toString()).to.be.equal("3");
+    });
 
-  it('Force full withdraw', async () => {
+    it("Force full withdraw", async () => {
     // Force full balance withdraw
     // In order to do force withdraw, the user must prove:
     // - a leaf exist on the balance tree given the last root
     // - function must be called from 'withdraw address' which is included in the balance tree leaf
 
-    // get merkle tree proof from balance tree
-    const id = BigInt(1);
-    const proofId = await balanceTree.getIdInfo(id);
-    const siblingsId = utils.arrayBigIntToArrayStr(proofId.siblings);
+        // get merkle tree proof from balance tree
+        const id = BigInt(1);
+        const proofId = await balanceTree.getIdInfo(id);
+        const siblingsId = utils.arrayBigIntToArrayStr(proofId.siblings);
 
-    const resForceFullWithdraw = await insRollupTest.forceFullWithdraw(
-      id.toString(),
-      proofId.foundObject.balance.toString(),
-      proofId.foundObject.tokenId.toString(),
-      proofId.foundObject.nonce.toString(),
-      [proofId.foundObject.Ax.toString(), proofId.foundObject.Ay.toString()],
-      siblingsId,
-      { from: withdrawAddress, value: web3.utils.toWei('1', 'ether') },
-    );
+        const resForceFullWithdraw = await insRollupTest.forceFullWithdraw(
+            id.toString(),
+            proofId.foundObject.balance.toString(),
+            proofId.foundObject.tokenId.toString(),
+            proofId.foundObject.nonce.toString(),
+            [proofId.foundObject.Ax.toString(), proofId.foundObject.Ay.toString()],
+            siblingsId,
+            { from: withdrawAddress, value: web3.utils.toWei("1", "ether") },
+        );
 
-    expect(resForceFullWithdraw.logs[0].event).to.be.equal('ForceFullWithdraw');
+        expect(resForceFullWithdraw.logs[0].event).to.be.equal("ForceFullWithdraw");
 
-    // Check balances tokens
-    const resRollup = await insTokenRollup.balanceOf(insRollupTest.address);
-    const resId1 = await insTokenRollup.balanceOf(id1);
-    const resOnTop = await insTokenRollup.balanceOf(onAddress);
-    const resWithdraw = await insTokenRollup.balanceOf(withdrawAddress);
+        // Check balances tokens
+        const resRollup = await insTokenRollup.balanceOf(insRollupTest.address);
+        const resId1 = await insTokenRollup.balanceOf(id1);
+        const resOnTop = await insTokenRollup.balanceOf(onAddress);
+        const resWithdraw = await insTokenRollup.balanceOf(withdrawAddress);
 
-    expect(resRollup.toString()).to.be.equal('0');
-    expect(resId1.toString()).to.be.equal('40');
-    expect(resOnTop.toString()).to.be.equal('25');
-    expect(resWithdraw.toString()).to.be.equal('35');
-  });
+        expect(resRollup.toString()).to.be.equal("0");
+        expect(resId1.toString()).to.be.equal("40");
+        expect(resOnTop.toString()).to.be.equal("25");
+        expect(resWithdraw.toString()).to.be.equal("35");
+    });
 
-  it('Forge batches force full withdraw', async () => {
+    it("Forge batches force full withdraw", async () => {
     // Forge first batch implies not balance tree state change at all
     // it only updates fillingOnChainTx to force insert previous 'forceFullWithdraw' Tx
     // we update second batch including force full withdraw on balance tree
-    let lastIndexStateRoot = await insRollupTest.getStateDepth();
-    lastIndexStateRoot = BigInt(lastIndexStateRoot) - BigInt(1);
-    const oldStateRoot = await insRollupTest.getStateRoot(lastIndexStateRoot.toString());
-    let newStateRoot = oldStateRoot;
-    const newExitRoot = BigInt(0).toString();
-    const onChainHash = BigInt(0).toString();
-    const feePlan = [BigInt(0).toString(), BigInt(0).toString()];
+        let lastIndexStateRoot = await insRollupTest.getStateDepth();
+        lastIndexStateRoot = BigInt(lastIndexStateRoot) - BigInt(1);
+        const oldStateRoot = await insRollupTest.getStateRoot(lastIndexStateRoot.toString());
+        let newStateRoot = oldStateRoot;
+        const newExitRoot = BigInt(0).toString();
+        const onChainHash = BigInt(0).toString();
+        const feePlan = [BigInt(0).toString(), BigInt(0).toString()];
 
-    const offChainTx = rollupUtils.createOffChainTx(1);
-    const offChainHash = offChainTx.hashOffChain.toString();
-    const compressedTxs = offChainTx.bytesTx;
+        const offChainTx = rollupUtils.createOffChainTx(1);
+        const offChainHash = offChainTx.hashOffChain.toString();
+        const compressedTxs = offChainTx.bytesTx;
 
-    const nTxPerToken = BigInt(0).toString();
+        const nTxPerToken = BigInt(0).toString();
 
-    const resForge = await insRollupTest.forgeBatchTest(oldStateRoot, newStateRoot, newExitRoot,
-      onChainHash, feePlan, compressedTxs, offChainHash, nTxPerToken, beneficiary);
+        const resForge = await insRollupTest.forgeBatchTest(oldStateRoot, newStateRoot, newExitRoot,
+            onChainHash, feePlan, compressedTxs, offChainHash, nTxPerToken, beneficiary);
 
-    expect(resForge.logs[0].event).to.be.equal('ForgeBatch');
-    expect(resForge.logs[0].args.batchNumber.toString()).to.be.equal('4');
-    expect(resForge.logs[0].args.offChainTx).to.be.equal(compressedTxs);
+        expect(resForge.logs[0].event).to.be.equal("ForgeBatch");
+        expect(resForge.logs[0].args.batchNumber.toString()).to.be.equal("4");
+        expect(resForge.logs[0].args.offChainTx).to.be.equal(compressedTxs);
 
-    // Update on-chain hashes
-    minningOnChainTest = await insRollupTest.getMinningOnChainTxsHash();
-    fillingOnChainTest = BigInt(0).toString();
+        // Update on-chain hashes
+        minningOnChainTest = await insRollupTest.getMinningOnChainTxsHash();
+        fillingOnChainTest = BigInt(0).toString();
 
-    // Calculate fillingOnChainHash
-    let resLeafValue = await balanceTree.getIdInfo(BigInt(1));
-    resLeafValue = resLeafValue.foundValue.toString();
-    // calculate filling on chain hash by the operator
-    let onChainHashOp = BigInt(0);
-    onChainHashOp = utils.hash([onChainHash, resLeafValue]);
+        // Calculate fillingOnChainHash
+        let resLeafValue = await balanceTree.getIdInfo(BigInt(1));
+        resLeafValue = resLeafValue.foundValue.toString();
+        // calculate filling on chain hash by the operator
+        let onChainHashOp = BigInt(0);
+        onChainHashOp = utils.hash([onChainHash, resLeafValue]);
 
-    expect(onChainHashOp.toString()).to.be.equal(BigInt(minningOnChainTest).toString());
+        expect(onChainHashOp.toString()).to.be.equal(BigInt(minningOnChainTest).toString());
 
-    // Update balance tree with 'deposit on top' transaction
-    await balanceTree.updateId(BigInt(1), BigInt(35));
-    newStateRoot = await balanceTree.getRoot();
-    newStateRoot = newStateRoot.toString();
-    const resForge2 = await insRollupTest.forgeBatchTest(oldStateRoot, newStateRoot,
-      newExitRoot, onChainHashOp.toString(), feePlan, compressedTxs, offChainHash, nTxPerToken, beneficiary);
+        // Update balance tree with 'deposit on top' transaction
+        await balanceTree.updateId(BigInt(1), BigInt(35));
+        newStateRoot = await balanceTree.getRoot();
+        newStateRoot = newStateRoot.toString();
+        const resForge2 = await insRollupTest.forgeBatchTest(oldStateRoot, newStateRoot,
+            newExitRoot, onChainHashOp.toString(), feePlan, compressedTxs, offChainHash, nTxPerToken, beneficiary);
 
-    expect(resForge2.logs[0].event).to.be.equal('ForgeBatch');
-    expect(resForge2.logs[0].args.batchNumber.toString()).to.be.equal('5');
-  });
+        expect(resForge2.logs[0].event).to.be.equal("ForgeBatch");
+        expect(resForge2.logs[0].args.batchNumber.toString()).to.be.equal("5");
+    });
 });

--- a/test/contracts/RollupPoS-functionalities.test.js
+++ b/test/contracts/RollupPoS-functionalities.test.js
@@ -4,15 +4,15 @@
 /* global contract */
 /* global web3 */
 
-const chai = require('chai');
+const chai = require("chai");
 
 const { expect } = chai;
-const RollupPoS = artifacts.require('../contracts/test/RollupPoSTest');
+const RollupPoS = artifacts.require("../contracts/test/RollupPoSTest");
 
 async function getEtherBalance(address) {
-  let balance = await web3.eth.getBalance(address);
-  balance = web3.utils.fromWei(balance, 'ether');
-  return Number(balance);
+    let balance = await web3.eth.getBalance(address);
+    balance = web3.utils.fromWei(balance, "ether");
+    return Number(balance);
 }
 
 // async function getTxGasSpent(resTx) {
@@ -22,182 +22,306 @@ async function getEtherBalance(address) {
 //   return Number(web3.utils.fromWei(gasSpent.toString(), 'ether'));
 // }
 
-contract('RollupPoS', (accounts) => {
-  const {
-    6: relayStaker,
-    7: beneficiaryAddress,
-    9: slashAddress,
-  } = accounts;
+contract("RollupPoS", (accounts) => {
+    const {
+        6: relayStaker,
+        7: beneficiaryAddress,
+        9: slashAddress,
+    } = accounts;
 
-  let insRollupPoS;
+    let insRollupPoS;
 
-  const addressRollupTest = '0x0000000000000000000000000000000000000001';
-  const operators = [];
-  const eraBlock = [];
-  const eraSlot = [];
-  const hashChain = [];
-  const blockPerEra = 2000;
-  const slotPerEra = 20;
-  let amountToStake = 2;
+    const addressRollupTest = "0x0000000000000000000000000000000000000001";
+    const operators = [];
+    const eraBlock = [];
+    const eraSlot = [];
+    const deadlineBlockPerSlot = [];
+    const hashChain = [];
+    const blockPerEra = 2000;
+    const slotPerEra = 20;
+    const blocksPerSlot = blockPerEra / slotPerEra;
+    const deadlineBlocks = 80;
+    let amountToStake = 2;
 
-  const initialMsg = 'rollup';
-  hashChain.push(web3.utils.keccak256(initialMsg));
-  for (let i = 1; i < 10; i++) {
-    hashChain.push(web3.utils.keccak256(hashChain[i - 1]));
-  }
+    const initialMsg = "rollup";
+    hashChain.push(web3.utils.keccak256(initialMsg));
+    for (let i = 1; i < 10; i++) {
+        hashChain.push(web3.utils.keccak256(hashChain[i - 1]));
+    }
 
-  before(async () => {
+    before(async () => {
     // Deploy token test
-    insRollupPoS = await RollupPoS.new(addressRollupTest);
-    // Initialization
-    // fill with first block of each era
-    const genesisBlockNum = await insRollupPoS.genesisBlock();
-    for (let i = 0; i < 20; i++) {
-      eraBlock.push(i * blockPerEra + Number(genesisBlockNum) + 1);
-      eraSlot.push(i * slotPerEra + 1);
-    }
-    // fill 5 addresses for operators
-    for (let i = 1; i < 6; i++) {
-      operators.push({ address: accounts[i], idOp: (i - 1).toString() });
-    }
-    // set first era block
-    await insRollupPoS.setBlockNumber(eraBlock[0]);
-  });
-
-  describe('functionalities', () => {
-    it('add operator', async () => {
-      let initBalOp = await getEtherBalance(operators[0].address);
-      // add operator 0 with eStake = 4
-      await insRollupPoS.addOperator(hashChain[9],
-        { from: operators[0].address, value: web3.utils.toWei(amountToStake.toString(), 'ether') });
-      const balOpAdd = await getEtherBalance(operators[0].address);
-      expect(Math.ceil(balOpAdd)).to.be.equal(Math.ceil(initBalOp) - 2);
-      // get back stake
-      await insRollupPoS.setBlockNumber(eraBlock[3]);
-      // try to get back stake from different operator
-      try {
-        await insRollupPoS.removeOperator(operators[0].idOp, { from: operators[1].address });
-      } catch (error) {
-        expect((error.message).includes('Sender does not match with operator controller')).to.be.equal(true);
-      }
-      initBalOp = await getEtherBalance(operators[0].address);
-      await insRollupPoS.removeOperator(operators[0].idOp, { from: operators[0].address });
-
-      // Era to remove operator
-      await insRollupPoS.setBlockNumber(eraBlock[4]);
-      try {
-        await insRollupPoS.withdraw(0);
-      } catch (error) {
-        expect((error.message).includes('Era to withdraw after current era')).to.be.equal(true);
-      }
-      // Era to remove operator
-      await insRollupPoS.setBlockNumber(eraBlock[5]);
-      await insRollupPoS.withdraw(0);
-
-      const balOpWithdraw = await getEtherBalance(operators[0].address);
-      expect(Math.ceil(initBalOp)).to.be.equal(Math.ceil(balOpWithdraw) - 2);
+        insRollupPoS = await RollupPoS.new(addressRollupTest);
+        // Initialization
+        // fill with first block of each era
+        const genesisBlockNum = await insRollupPoS.genesisBlock();
+        for (let i = 0; i < 20; i++) {
+            eraBlock.push(i * blockPerEra + Number(genesisBlockNum) + 1);
+            eraSlot.push(i * slotPerEra);
+            deadlineBlockPerSlot.push(Number(genesisBlockNum) + (i * blocksPerSlot) + deadlineBlocks);
+        }
+        // fill 5 addresses for operators
+        for (let i = 1; i < 6; i++) {
+            operators.push({ address: accounts[i], idOp: (i - 1).toString() });
+        }
+        // set first era block
+        await insRollupPoS.setBlockNumber(eraBlock[0]);
     });
 
-    it('add operator with different beneficiary address', async () => {
-      const initBalance = await getEtherBalance(beneficiaryAddress);
-      await insRollupPoS.setBlockNumber(eraBlock[5]);
-      // add operator 1 with eStake = 4
-      await insRollupPoS.addOperatorWithDifferentBeneficiary(beneficiaryAddress, hashChain[9],
-        { from: operators[1].address, value: web3.utils.toWei(amountToStake.toString(), 'ether') });
-      await insRollupPoS.setBlockNumber(eraBlock[6]);
-      await insRollupPoS.removeOperator(1, { from: operators[1].address });
-      await insRollupPoS.setBlockNumber(eraBlock[8]);
-      await insRollupPoS.withdraw(1);
-      // Check balance beneficiary Address
-      const balance = await getEtherBalance(beneficiaryAddress);
-      expect(initBalance + 2).to.be.equal(balance);
+    describe("functionalities", () => {
+        it("add operator", async () => {
+            let initBalOp = await getEtherBalance(operators[0].address);
+            // add operator 0 with eStake = 4
+            await insRollupPoS.addOperator(hashChain[9],
+                { from: operators[0].address, value: web3.utils.toWei(amountToStake.toString(), "ether") });
+            const balOpAdd = await getEtherBalance(operators[0].address);
+            expect(Math.ceil(balOpAdd)).to.be.equal(Math.ceil(initBalOp) - 2);
+            // get back stake
+            await insRollupPoS.setBlockNumber(eraBlock[3]);
+            // try to get back stake from different operator
+            try {
+                await insRollupPoS.removeOperator(operators[0].idOp, { from: operators[1].address });
+            } catch (error) {
+                expect((error.message).includes("Sender does not match with operator controller")).to.be.equal(true);
+            }
+            initBalOp = await getEtherBalance(operators[0].address);
+            await insRollupPoS.removeOperator(operators[0].idOp, { from: operators[0].address });
+
+            // Era to remove operator
+            await insRollupPoS.setBlockNumber(eraBlock[4]);
+            try {
+                await insRollupPoS.withdraw(0);
+            } catch (error) {
+                expect((error.message).includes("Era to withdraw after current era")).to.be.equal(true);
+            }
+            // Era to remove operator
+            await insRollupPoS.setBlockNumber(eraBlock[5]);
+            await insRollupPoS.withdraw(0);
+
+            const balOpWithdraw = await getEtherBalance(operators[0].address);
+            expect(Math.ceil(initBalOp)).to.be.equal(Math.ceil(balOpWithdraw) - 2);
+        });
+
+        it("add operator with different beneficiary address", async () => {
+            const initBalance = await getEtherBalance(beneficiaryAddress);
+            await insRollupPoS.setBlockNumber(eraBlock[5]);
+            // add operator 1 with eStake = 4
+            await insRollupPoS.addOperatorWithDifferentBeneficiary(beneficiaryAddress, hashChain[9],
+                { from: operators[1].address, value: web3.utils.toWei(amountToStake.toString(), "ether") });
+            await insRollupPoS.setBlockNumber(eraBlock[6]);
+            await insRollupPoS.removeOperator(1, { from: operators[1].address });
+            await insRollupPoS.setBlockNumber(eraBlock[8]);
+            await insRollupPoS.withdraw(1);
+            // Check balance beneficiary Address
+            const balance = await getEtherBalance(beneficiaryAddress);
+            expect(initBalance + 2).to.be.equal(balance);
+        });
+
+        it("add operator with different beneficiary address and relay staker", async () => {
+            const initBalanceRelay = await getEtherBalance(relayStaker);
+            const initBalOp = await getEtherBalance(operators[2].address);
+            const initBalBeneficiary = await getEtherBalance(beneficiaryAddress);
+            await insRollupPoS.setBlockNumber(eraBlock[8]);
+            // add operator 2 with stakerAddress commiting 2 ether
+            await insRollupPoS.addOperatorRelay(operators[2].address, beneficiaryAddress, hashChain[9],
+                { from: relayStaker, value: web3.utils.toWei(amountToStake.toString(), "ether") });
+
+            const balanceRelay0 = await getEtherBalance(relayStaker);
+            const balOp0 = await getEtherBalance(operators[2].address);
+            const balBeneficiary0 = await getEtherBalance(beneficiaryAddress);
+            // check balances of all addresses
+            expect(Math.ceil(initBalanceRelay) - 2).to.be.equal(Math.ceil(balanceRelay0));
+            expect(initBalOp).to.be.equal(balOp0);
+            expect(initBalBeneficiary).to.be.equal(balBeneficiary0);
+            // sign ethereum message and build signature
+            const hashMsg = web3.utils.soliditySha3("RollupPoS", "remove", { type: "uint32", value: operators[2].idOp });
+            const sigOp = await web3.eth.sign(hashMsg, operators[2].address);
+            const r = sigOp.substring(0, 66);
+            const s = `0x${sigOp.substring(66, 130)}`;
+            const v = Number(sigOp.substring(130, 132)) + 27;
+            // remove operator and withdraw
+            await insRollupPoS.setBlockNumber(eraBlock[7]);
+            await insRollupPoS.removeOperatorRelay(operators[2].idOp, r, s, v.toString());
+            await insRollupPoS.setBlockNumber(eraBlock[9]);
+            await insRollupPoS.withdraw(operators[2].idOp);
+            // check
+            const balanceRelay1 = await getEtherBalance(relayStaker);
+            const balOp1 = await getEtherBalance(operators[2].address);
+            const balBeneficiary1 = await getEtherBalance(beneficiaryAddress);
+            expect(balanceRelay0).to.be.equal(balanceRelay1);
+            expect(balOp1).to.be.equal(balOp1);
+            expect(balBeneficiary0 + 2).to.be.equal(balBeneficiary1);
+        });
+
+        it("slash operator", async () => {
+            amountToStake = 20;
+            const initBalOp = await getEtherBalance(operators[0].address);
+            const initBalanceSlash = await getEtherBalance(slashAddress);
+            // reset rollup PoS
+            insRollupPoS = await RollupPoS.new(addressRollupTest);
+            await insRollupPoS.setBlockNumber(eraBlock[0]);
+            await insRollupPoS.addOperator(hashChain[9],
+                { from: operators[0].address, value: web3.utils.toWei(amountToStake.toString(), "ether") });
+            await insRollupPoS.setBlockNumber(eraBlock[1]);
+            try {
+                await insRollupPoS.slash(eraSlot[2], { from: slashAddress });
+            } catch (error) {
+                expect((error.message).includes("Slot requested still does not exist")).to.be.equal(true);
+            }
+            try {
+                await insRollupPoS.slash(eraSlot[0], { from: slashAddress });
+            } catch (error) {
+                expect((error.message).includes("Must be stakers")).to.be.equal(true);
+            }
+            await insRollupPoS.setBlockNumber(eraBlock[3]);
+            // Check balances before slashing
+            let balOp = await getEtherBalance(operators[0].address);
+            let balSlash = await getEtherBalance(slashAddress);
+
+            expect(Math.ceil(initBalOp)).to.be.equal(Math.ceil(balOp) + amountToStake);
+            expect(Math.ceil(initBalanceSlash)).to.be.equal(Math.ceil(balSlash));
+
+            await insRollupPoS.slash(eraSlot[2], { from: slashAddress });
+            // Check balances after slashing
+            balOp = await getEtherBalance(operators[0].address);
+            balSlash = await getEtherBalance(slashAddress);
+            // operator 1 lose its amount staked
+            expect(Math.ceil(initBalOp)).to.be.equal(Math.ceil(balOp) + amountToStake);
+            // slash account to receive 10% of amount staked
+            expect(Math.ceil(initBalanceSlash) + 0.1 * amountToStake).to.be.equal(Math.ceil(balSlash));
+
+            // Add operator again
+            await insRollupPoS.addOperator(hashChain[9],
+                { from: operators[0].address, value: web3.utils.toWei(amountToStake.toString(), "ether") });
+            await insRollupPoS.setBlockNumber(eraBlock[6]);
+            // simulate operator has forge a batch
+            await insRollupPoS.setBlockForged(eraSlot[5]);
+            // try to slash operator
+            try {
+                await insRollupPoS.slash(eraSlot[5], { from: slashAddress });
+            } catch (error) {
+                expect((error.message).includes("Batch has been commited and forged during this slot")).to.be.equal(true);
+            }
+        });
+
+        it("commit and forge batch", async () => {
+            const compressedTxTest = "0x010203040506070809";
+            const proofA = ["0", "0"];
+            const proofB = [["0", "0"], ["0", "0"]];
+            const proofC = ["0", "0"];
+            const input = ["0", "0", "0", "0", "0", "0", "0", "0"];
+            // reset rollup PoS
+            insRollupPoS = await RollupPoS.new(addressRollupTest);
+            await insRollupPoS.setBlockNumber(eraBlock[0]);
+            await insRollupPoS.addOperator(hashChain[9],
+                { from: operators[0].address, value: web3.utils.toWei(amountToStake.toString(), "ether") });
+            await insRollupPoS.setBlockNumber(eraBlock[1]);
+            await insRollupPoS.setBlockNumber(eraBlock[3]);
+            // try to commit batch with wrong previous hash
+            try {
+                await insRollupPoS.commitBatch(hashChain[7], compressedTxTest);
+            } catch(error) {
+                expect((error.message).includes("hash revelead not match current commited hash")).to.be.equal(true);
+            }
+            // check commit bash
+            const resCommit = await insRollupPoS.commitBatch(hashChain[8], compressedTxTest);
+            expect(resCommit.logs[0].event).to.be.equal("dataCommited");
+            expect(resCommit.logs[0].args.slot.toString()).to.be.equal(eraSlot[3].toString());
+            expect(resCommit.logs[0].args.blockNumber.toString()).to.be.equal(eraBlock[3].toString());
+            expect(resCommit.logs[0].args.compressedTx).to.be.equal(compressedTxTest);
+            // try to update data commited before without forging
+            try {
+                await insRollupPoS.commitBatch(hashChain[8], compressedTxTest);
+            } catch(error) {
+                expect((error.message).includes("there is data which is not forged")).to.be.equal(true);
+            }
+            
+            // Forge batch
+            await insRollupPoS.forgeCommitedBatch(proofA, proofB, proofC, input);
+
+            // try to forge data where there is no data commited
+            try {
+                await insRollupPoS.forgeCommitedBatch(proofA, proofB, proofC, input);
+            } catch (error) {
+                expect((error.message).includes("There is no commited data")).to.be.equal(true);
+            }
+
+            // commit data just before deadline
+            await insRollupPoS.setBlockNumber(eraBlock[3] + deadlineBlocks - 2);
+            await insRollupPoS.commitBatch(hashChain[7], compressedTxTest);
+            await insRollupPoS.forgeCommitedBatch(proofA, proofB, proofC, input);
+
+            // try to commit just after the deadline
+            await insRollupPoS.setBlockNumber(eraBlock[3] + deadlineBlocks + 1);
+            try { 
+                await insRollupPoS.commitBatch(hashChain[6], compressedTxTest);
+            } catch (error) {
+                expect((error.message).includes("not possible to commit data afer deadline")).to.be.equal(true);
+            }
+
+            // move forward just one slot
+            await insRollupPoS.setBlockNumber(eraBlock[3] + blocksPerSlot);
+            // try to slash operator
+            try {
+                await insRollupPoS.slash(eraSlot[3]);
+            } catch(error) {
+                expect((error.message).includes("Batch has been commited and forged during this slot")).to.be.equal(true);
+            }
+
+            // commit data before deadline, try to update it, not forge block and slash operator
+            // commit and forge
+            await insRollupPoS.commitBatch(hashChain[6], compressedTxTest);
+            await insRollupPoS.forgeCommitedBatch(proofA, proofB, proofC, input);
+            // commit again but not forge
+            await insRollupPoS.commitBatch(hashChain[5], compressedTxTest);
+            // move forward and try to update commited info
+            await insRollupPoS.setBlockNumber(eraBlock[3] + blocksPerSlot + deadlineBlocks);
+            try {
+                await insRollupPoS.commitBatch(hashChain[5], compressedTxTest);
+            } catch(error) {
+                expect((error.message).includes("not possible to commit data afer deadline")).to.be.equal(true);
+            }
+            // move formward next slot without forging
+            await insRollupPoS.setBlockNumber(eraBlock[3] + 2*blocksPerSlot);
+            // slash operator despite a block has been forged
+            // but it commited data and has not forge commited data
+            try {
+                await insRollupPoS.slash(eraSlot[3]);
+            } catch(error) {
+                expect((error.message).includes("Batch has been commited and forged during this slot")).to.be.equal(true);
+            }
+            await insRollupPoS.slash(eraSlot[3] + 1);
+            // move forward and be sure that there are no operators
+            await insRollupPoS.setBlockNumber(eraBlock[5]);
+            try {
+                await insRollupPoS.getRaffleWinner(eraSlot[3]);
+            } catch (error) {
+                expect((error.message).includes("Must be stakers")).to.be.equal(true);
+            }
+        });
+
+        it("slash operator with no commitment data", async () => {
+            // reset rollup PoS
+            insRollupPoS = await RollupPoS.new(addressRollupTest);
+            await insRollupPoS.setBlockNumber(eraBlock[0]);
+            await insRollupPoS.addOperator(hashChain[9],
+                { from: operators[0].address, value: web3.utils.toWei(amountToStake.toString(), "ether") });
+            await insRollupPoS.setBlockNumber(eraBlock[1]);
+            await insRollupPoS.setBlockNumber(eraBlock[3]);
+            // Balance before slashing
+            const initBalSlash = await getEtherBalance(slashAddress);
+            // slash operator 
+            await insRollupPoS.slash(eraSlot[2], { from: slashAddress });
+            // balance after slash operator
+            const balSlash = await getEtherBalance(slashAddress);
+            expect(Math.ceil(initBalSlash) + 0.1 * amountToStake).to.be.equal(Math.ceil(balSlash));
+            // Assure no operators after slashing
+            await insRollupPoS.setBlockNumber(eraBlock[5]);
+            try {
+                await insRollupPoS.getRaffleWinner(eraSlot[3]);
+            } catch (error) {
+                expect((error.message).includes("Must be stakers")).to.be.equal(true);
+            }
+        });
     });
-
-    it('add operator with different beneficiary address and relay staker', async () => {
-      const initBalanceRelay = await getEtherBalance(relayStaker);
-      const initBalOp = await getEtherBalance(operators[2].address);
-      const initBalBeneficiary = await getEtherBalance(beneficiaryAddress);
-      await insRollupPoS.setBlockNumber(eraBlock[8]);
-      // add operator 2 with stakerAddress commiting 2 ether
-      await insRollupPoS.addOperatorRelay(operators[2].address, beneficiaryAddress, hashChain[9],
-        { from: relayStaker, value: web3.utils.toWei(amountToStake.toString(), 'ether') });
-
-      const balanceRelay0 = await getEtherBalance(relayStaker);
-      const balOp0 = await getEtherBalance(operators[2].address);
-      const balBeneficiary0 = await getEtherBalance(beneficiaryAddress);
-      // check balances of all addresses
-      expect(Math.ceil(initBalanceRelay) - 2).to.be.equal(Math.ceil(balanceRelay0));
-      expect(initBalOp).to.be.equal(balOp0);
-      expect(initBalBeneficiary).to.be.equal(balBeneficiary0);
-      // sign ethereum message and build signature
-      const hashMsg = web3.utils.soliditySha3('RollupPoS', 'remove', { type: 'uint32', value: operators[2].idOp });
-      const sigOp = await web3.eth.sign(hashMsg, operators[2].address);
-      const r = sigOp.substring(0, 66);
-      const s = `0x${sigOp.substring(66, 130)}`;
-      const v = Number(sigOp.substring(130, 132)) + 27;
-      // remove operator and withdraw
-      await insRollupPoS.setBlockNumber(eraBlock[7]);
-      await insRollupPoS.removeOperatorRelay(operators[2].idOp, r, s, v.toString());
-      await insRollupPoS.setBlockNumber(eraBlock[9]);
-      await insRollupPoS.withdraw(operators[2].idOp);
-      // check
-      const balanceRelay1 = await getEtherBalance(relayStaker);
-      const balOp1 = await getEtherBalance(operators[2].address);
-      const balBeneficiary1 = await getEtherBalance(beneficiaryAddress);
-      expect(balanceRelay0).to.be.equal(balanceRelay1);
-      expect(balOp1).to.be.equal(balOp1);
-      expect(balBeneficiary0 + 2).to.be.equal(balBeneficiary1);
-    });
-
-    it('slash operator', async () => {
-      amountToStake = 20;
-      const initBalOp = await getEtherBalance(operators[0].address);
-      const initBalanceSlash = await getEtherBalance(slashAddress);
-      // reset rollup PoS
-      insRollupPoS = await RollupPoS.new(addressRollupTest);
-      await insRollupPoS.setBlockNumber(eraBlock[0]);
-      await insRollupPoS.addOperator(hashChain[9],
-        { from: operators[0].address, value: web3.utils.toWei(amountToStake.toString(), 'ether') });
-      await insRollupPoS.setBlockNumber(eraBlock[1]);
-      try {
-        await insRollupPoS.slash(eraSlot[2], { from: slashAddress });
-      } catch (error) {
-        expect((error.message).includes('Slot requested still does not exist')).to.be.equal(true);
-      }
-      try {
-        await insRollupPoS.slash(eraSlot[0], { from: slashAddress });
-      } catch (error) {
-        expect((error.message).includes('Must be stakers')).to.be.equal(true);
-      }
-      await insRollupPoS.setBlockNumber(eraBlock[3]);
-      // Check balances before slashing
-      let balOp = await getEtherBalance(operators[0].address);
-      let balSlash = await getEtherBalance(slashAddress);
-
-      expect(Math.ceil(initBalOp)).to.be.equal(Math.ceil(balOp) + amountToStake);
-      expect(Math.ceil(initBalanceSlash)).to.be.equal(Math.ceil(balSlash));
-
-      await insRollupPoS.slash(eraSlot[2], { from: slashAddress });
-      // Check balances after slashing
-      balOp = await getEtherBalance(operators[0].address);
-      balSlash = await getEtherBalance(slashAddress);
-      // operator 1 lose its amount staked
-      expect(Math.ceil(initBalOp)).to.be.equal(Math.ceil(balOp) + amountToStake);
-      // slash account to receive 10% of amount staked
-      expect(Math.ceil(initBalanceSlash) + 0.1 * amountToStake).to.be.equal(Math.ceil(balSlash));
-
-      // Add operator again
-      await insRollupPoS.addOperator(hashChain[9],
-        { from: operators[0].address, value: web3.utils.toWei(amountToStake.toString(), 'ether') });
-      await insRollupPoS.setBlockNumber(eraBlock[6]);
-      // simulate operator has forge a batch
-      await insRollupPoS.setBlockForged(eraSlot[5]);
-      // try to slash operator
-      try {
-        await insRollupPoS.slash(eraSlot[5], { from: slashAddress });
-      } catch (error) {
-        expect((error.message).includes('Batch has been forged during this slot')).to.be.equal(true);
-      }
-    });
-  });
 });


### PR DESCRIPTION
- separate `forgeBatchPoS` functionality into two steps:
  - `commitBatch`
  - `forgeCommitedBatch`

A `deadline` has been introduced by each slot. This `deadline` means that operator are not allowed to commit any more data after `deadline`.
This allows following operators to start proof calculation before the beginning of its assigned slot.
If operators commits data but afterwards this data is not forged, the operator could be slashed.

*Note: both implementations, one step forging and two steps, are implemented until clean up code