### PR TITLE
specify string format

### DIFF
--- a/rollup-utils/babyjub-wallet-utils.js
+++ b/rollup-utils/babyjub-wallet-utils.js
@@ -2,7 +2,7 @@ const cryptoLib = require("crypto");
 
 function getMac(keyBuff, encryptedDataBuff) {
     const concatBuff = Buffer.concat([keyBuff.slice(0, 16), encryptedDataBuff]);
-    return cryptoLib.createHmac("sha256", concatBuff.toString()).digest("base64");
+    return cryptoLib.createHmac("sha256", concatBuff.toString("base64")).digest("base64");
 }
 
 function passToKey(pass, salt, iterations, keyLen, digest) {


### PR DESCRIPTION
Either `encrypted data` and `key` are coded as `base64` strings.
Those strings are concatenated through Buffers and the given result is used to create `hmac`.
At the time to convert Buffer to string no format was specified. Hence, `utf-8` is the default encoding. Then, `base64` strings are converted to buffers and then this buffer is encoded to `utf-8`. There is no issue associated with `node` at the time to compute `hmac` but some browsers or font types could have incompatibilities due to `utf-8` special characters.
Therefore, strings are coded and encoded using `base64` format.