### PR TITLE
update test circuit, update batchbuilder

### DIFF
--- a/js/batchbuilder.js
+++ b/js/batchbuilder.js
@@ -165,15 +165,12 @@ module.exports = class BatchBuilder {
 
         let effectiveAmount = amount;
         const underFlowOk = (oldState1.amount.add(loadAmount).sub(amount).sub(operatorFee).greaterOrEquals(bigInt(0)));
-        const overflowOk = (oldState2.amount.add(amount).lesser(bigInt(1).shl(128)));
-        const txOk = underFlowOk && overflowOk;
-        if (!txOk) {
+        if (!underFlowOk) {
             if (tx.onChain) {
                 effectiveAmount = bigInt(0);
             } else {
                 let errStr = "Error ";
                 if (!underFlowOk) errStr = "underflow";
-                if (!overflowOk) errStr = "overflow";
                 throw new Error(errStr);
             }
         }
@@ -200,9 +197,6 @@ module.exports = class BatchBuilder {
         }
         const newState2 = Object.assign({}, oldState2);
         newState2.amount = oldState2.amount.add(effectiveAmount);
-        if (!tx.onChain && op2 == "UPDATE" && isExit) {
-            newState2.nonce++;
-        }
 
         if (op1=="INSERT") {
 
@@ -213,6 +207,7 @@ module.exports = class BatchBuilder {
             while (siblings.length<this.nLevels+1) siblings.push(bigInt(0));
 
             // State 1
+            //That first 4 parameters do not matter in the circuit, since it gets the information from the TxData
             this.input.ax1[i]= 0x1234;      // It should not matter
             this.input.ay1[i]= 0x1234;      // It should not matter
             this.input.amount1[i]= 0x1234;  // It should not matter
@@ -251,11 +246,12 @@ module.exports = class BatchBuilder {
             while (siblings.length<this.nLevels+1) siblings.push(bigInt(0));
 
             // State 1
-            this.input.ax1[i]= bigInt("0x" + oldState1.ax);      // It should not matter
-            this.input.ay1[i]= bigInt("0x" + oldState1.ay);      // It should not matter
-            this.input.amount1[i]= oldState1.amount;  // It should not matter
-            this.input.nonce1[i]= oldState1.nonce;   // It should not matter
-            this.input.ethAddr1[i]= bigInt(oldState1.ethAddress); // It should not matter
+            //It should not matter what the Tx have, because we get the input from the oldState
+            this.input.ax1[i]= bigInt("0x" + oldState1.ax);
+            this.input.ay1[i]= bigInt("0x" + oldState1.ay);
+            this.input.amount1[i]= oldState1.amount;  
+            this.input.nonce1[i]= oldState1.nonce; 
+            this.input.ethAddr1[i]= bigInt(oldState1.ethAddress);
 
 
             this.input.siblings1[i] = siblings;
@@ -302,11 +298,12 @@ module.exports = class BatchBuilder {
                 while (siblings.length<this.nLevels+1) siblings.push(bigInt(0));
 
                 // State 2
-                this.input.ax2[i]= bigInt("0x" + oldState2.ax);      // It should not matter
-                this.input.ay2[i]= bigInt("0x" + oldState2.ay);      // It should not matter
-                this.input.amount2[i]= oldState2.amount;  // It should not matter
-                this.input.nonce2[i]= oldState2.nonce;   // It should not matter
-                this.input.ethAddr2[i]= bigInt(oldState2.ethAddress); // It should not matter
+                //It should not matter what the Tx have, because we get the input from the oldState
+                this.input.ax2[i]= bigInt("0x" + oldState2.ax);
+                this.input.ay2[i]= bigInt("0x" + oldState2.ay);
+                this.input.amount2[i]= oldState2.amount;
+                this.input.nonce2[i]= oldState2.nonce; 
+                this.input.ethAddr2[i]= bigInt(oldState2.ethAddress);
 
 
                 this.input.siblings2[i] = siblings;
@@ -324,11 +321,12 @@ module.exports = class BatchBuilder {
                 while (siblings.length<this.nLevels+1) siblings.push(bigInt(0));
 
                 // State 2
-                this.input.ax2[i]= bigInt("0x" + oldState2.ax);      // It should not matter
-                this.input.ay2[i]= bigInt("0x" + oldState2.ay);      // It should not matter
-                this.input.amount2[i]= oldState2.amount;  // It should not matter
-                this.input.nonce2[i]= oldState2.nonce;   // It should not matter
-                this.input.ethAddr2[i]= bigInt(oldState2.ethAddress); // It should not matter
+                //It should not matter what the Tx have, because we get the input from the oldState
+                this.input.ax2[i]= bigInt("0x" + oldState2.ax);
+                this.input.ay2[i]= bigInt("0x" + oldState2.ay);
+                this.input.amount2[i]= oldState2.amount;
+                this.input.nonce2[i]= oldState2.nonce;
+                this.input.ethAddr2[i]= bigInt(oldState2.ethAddress);
 
 
                 this.input.siblings2[i] = siblings;

--- a/rollup-cli/src/actions/onchain/deposit-and-transfer.js
+++ b/rollup-cli/src/actions/onchain/deposit-and-transfer.js
@@ -9,6 +9,7 @@ const { Wallet } = require('../../wallet.js');
  * @param tokenId token type identifier
  * @param walletJson from this one can obtain the ethAddress and babyPubKey
  * @param password for decrypt the Wallet
+ * @param ethAddress allowed address to control new balance tree leaf
  * @param abi abi of rollup contract
  * @param UrlOperator URl from operator
 */

--- a/rollup-cli/src/actions/onchain/deposit.js
+++ b/rollup-cli/src/actions/onchain/deposit.js
@@ -10,7 +10,7 @@ const { Wallet } = require('../../wallet.js');
  * @param tokenId token type identifier
  * @param walletJson from this one can obtain the ethAddress and babyPubKey
  * @param password for decrypt the Wallet
- * @param ethAddress ethereum address to be added on balance tree
+ * @param ethAddress allowed address to control new balance tree leaf
  * @param abi abi of rollup contract
 */
 async function deposit(urlNode, addressSC, balance, tokenId, walletJson, password, ethAddress, abi) {

--- a/rollup-cli/tools/helpers/createWallets.js
+++ b/rollup-cli/tools/helpers/createWallets.js
@@ -14,7 +14,7 @@ async function createWallets(numWallets, amountToken, passString, addressRollup,
     walletEthFunder = walletEthFunder.connect(provider);
     const contractTokensFunder = new ethers.Contract(addressTokens, abiTokens, walletEthFunder);
     const addressFunder = await walletEthFunder.getAddress();
-    const tokensFunder = await contractTokensFunder.balanceOf(addressFunder); // is contract=?
+    const tokensFunder = await contractTokensFunder.balanceOf(addressFunder);
     const balanceFunder = await walletEthFunder.getBalance();
 
     if (balanceFunder < amountEther) {

--- a/test/rollup_circuit.js
+++ b/test/rollup_circuit.js
@@ -106,7 +106,7 @@ describe("Rollup Basic circuit TXs", function () {
 
         checkBatch(circuit, w, bb);
     });
-    it("Should create 2 deposits and then a normal offchain transfer", async () => {
+    it("Should create 2 deposits and then offchain transfer", async () => {
 
         // Start a new state
         const db = new SMTMemDB();
@@ -155,6 +155,83 @@ describe("Rollup Basic circuit TXs", function () {
             userFee: 10
         };
         account1.signTx(tx);
+        bb2.addTx(tx);
+
+        bb2.addCoin(0, 5);
+       
+        await bb2.build();
+        const input2 = bb2.getInput();
+        
+        const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w2, bb2);
+    });
+    it("Should create 2 deposits and then 3 offchain transfer", async () => {
+
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+
+        const account1 = new RollupAccount(1);
+        const account2 = new RollupAccount(2);
+
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+
+        bb.addTx({
+            fromIdx: 2,
+            loadAmount: 2000,
+            coin: 0,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        });
+
+        await bb.build();
+        const input = bb.getInput();
+
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+
+        await rollupDB.consolidate(bb);
+
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+
+        const tx = {
+            fromIdx: 1,
+            toIdx: 2,
+            coin: 0,
+            amount: 50,
+            nonce: 0,
+            userFee: 10
+        };
+        const tx2 = {
+            fromIdx: 2,
+            toIdx: 1,
+            coin: 0,
+            amount: 100,
+            nonce: 0,
+            userFee: 10
+        };
+        const tx3 = {
+            fromIdx: 1,
+            toIdx: 2,
+            coin: 0,
+            amount: 50,
+            nonce: 1,
+            userFee: 10
+        };
+        account1.signTx(tx);
+        account2.signTx(tx2);
+        account1.signTx(tx3);
         bb2.addTx(tx);
 
         bb2.addCoin(0, 5);
@@ -373,8 +450,840 @@ describe("Rollup Basic circuit TXs", function () {
         checkBatch(circuit, w, bb);
     });
 
-    it("Should create 2 deposits and then a normal offchain transfer to 0", async () => {
+    it("Should create a deposit and then offchain transfer to 0", async () => {
 
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+
+        const account1 = new RollupAccount(1);
+
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+        await bb.build();
+        const input = bb.getInput();
+
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+
+        await rollupDB.consolidate(bb);
+
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+
+        const tx = {
+            fromIdx: 1,
+            toIdx: 0,
+            coin: 0,
+            amount: 50,
+            nonce: 0,
+            userFee: 10
+        };
+        account1.signTx(tx);
+        bb2.addTx(tx);
+        bb2.addCoin(0, 5);
+       
+        await bb2.build();
+        const input2 = bb2.getInput();
+        const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w2, bb2);
+    });
+    it("Should create a deposit and then 4 offchain transfer, 3 of them to 0", async () => {
+
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+
+        const account1 = new RollupAccount(1);
+
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+
+        bb.addTx({
+            fromIdx: 2,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+        await bb.build();
+        const input = bb.getInput();
+
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+
+        await rollupDB.consolidate(bb);
+
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+
+        const tx = {
+            fromIdx: 1,
+            toIdx: 2,
+            coin: 0,
+            amount: 50,
+            nonce: 0,
+            userFee: 10
+        };
+        account1.signTx(tx);
+
+        const tx2 = {
+            fromIdx: 1,
+            toIdx: 0,
+            coin: 0,
+            amount: 10,
+            nonce: 1,
+            userFee: 10
+        };
+        account1.signTx(tx2);
+
+
+        const tx3 = {
+            fromIdx: 1,
+            toIdx: 0,
+            coin: 0,
+            amount: 200,
+            nonce: 2,
+            userFee: 10
+        };
+        account1.signTx(tx3);
+        const tx4 = {
+            fromIdx: 1,
+            toIdx: 0,
+            coin: 0,
+            amount: 100,
+            nonce: 3,
+            userFee: 10
+        };
+        account1.signTx(tx4);
+        bb2.addTx(tx);
+        bb2.addTx(tx2);
+        bb2.addTx(tx3);
+        bb2.addTx(tx4);
+        bb2.addCoin(0, 5);
+       
+        await bb2.build();
+        const input2 = bb2.getInput();
+        const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w2, bb2);
+        await rollupDB.consolidate(bb2);
+        const s2_1 = await rollupDB.getStateByIdx(1);
+        assert.equal(s2_1.amount.toString(), 620);
+    });
+   
+    it("Should create a deposit and then an onchain forceWithdraw and 2 offchain send to 0", async () => {
+
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+
+        const account1 = new RollupAccount(1);
+
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 100,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+
+        await bb.build();
+        const input = bb.getInput();
+
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+
+        await rollupDB.consolidate(bb);
+
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+
+        //10
+        const tx1 = {
+            fromIdx: 1,
+            toIdx: 0,
+            coin: 0,
+            amount: 40,
+            nonce: 0,
+            userFee: 5
+        };
+        account1.signTx(tx1);
+
+        const tx2 = {
+            fromIdx: 1,
+            toIdx: 0,
+            coin: 0,
+            amount: 40,
+            nonce: 1,
+            userFee: 5
+        };
+        account1.signTx(tx2);
+
+        const tx3 = {
+            fromIdx: 1,
+            toIdx: 0,
+            coin: 0,
+            amount: 30,
+            nonce: 2,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        };
+
+        bb2.addTx(tx1);
+        bb2.addTx(tx2);
+        bb2.addTx(tx3);
+        bb2.addCoin(0, 5);
+       
+        await bb2.build();
+        const input2 = bb2.getInput();
+        const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w2, bb2);
+        await rollupDB.consolidate(bb2);
+        const s2_1 = await rollupDB.getStateByIdx(1);
+        assert.equal(s2_1.amount.toString(), 10);
+    });
+    it("Should check underflow offchain", async () => { 
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+  
+        const account1 = new RollupAccount(1);
+        const account2 = new RollupAccount(2);
+  
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+  
+        bb.addTx({
+            fromIdx: 2,
+            loadAmount: 2000,
+            coin: 0,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        });
+  
+        await bb.build();
+        const input = bb.getInput();
+  
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+  
+        await rollupDB.consolidate(bb);
+  
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+  
+        const tx = {
+            fromIdx: 1,
+            toIdx: 2,
+            coin: 0,
+            amount: 5000,
+            nonce: 0,
+            userFee: 10
+        };
+        account1.signTx(tx);
+        bb2.addTx(tx);
+        bb2.addCoin(0, 5);
+
+        try{
+            await bb2.build();
+            const input2 = bb2.getInput();
+              
+            const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+            checkBatch(circuit, w2, bb2);
+        }
+        catch(error){
+            assert.include(error.message, "underflow");
+        }
+    });
+    it("Should check underflow onchain", async () => { 
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+  
+        const account1 = new RollupAccount(1);
+        const account2 = new RollupAccount(2);
+  
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+  
+        bb.addTx({
+            fromIdx: 2,
+            loadAmount: 2000,
+            coin: 0,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        });
+  
+        await bb.build();
+        const input = bb.getInput();
+  
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+  
+        await rollupDB.consolidate(bb);
+  
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+  
+        const tx = {
+            fromIdx: 1,
+            toIdx: 2,
+            coin: 0,
+            amount: 5000,
+            nonce: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        };
+        bb2.addTx(tx);
+
+        await bb2.build();
+        const input2 = bb2.getInput();
+            
+        const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w2, bb2);
+        await rollupDB.consolidate(bb2);
+        const s2_1 = await rollupDB.getStateByIdx(1);
+        const s2_2 = await rollupDB.getStateByIdx(2);
+        assert.equal(s2_1.amount.toString(), 1000);
+        assert.equal(s2_2.amount.toString(), 2000);
+        
+    });
+    it("Should check onchain deposit of 128 bits", async () => { // should SC prevent this
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+          
+        const account1 = new RollupAccount(1);
+          
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: bigInt(1).shl(128),
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+        
+        await bb.build();
+        const input = bb.getInput();
+              
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+        await rollupDB.consolidate(bb);
+        const s2_1 = await rollupDB.getStateByIdx(1);
+        assert.equal(s2_1.amount.toString(), 340282366920938463463374607431768211456);
+
+    });
+    
+    it("Should check offchain with loadAmount", async () => {
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+        
+        const account1 = new RollupAccount(1);
+        const account2 = new RollupAccount(2);
+        
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+        
+        bb.addTx({
+            fromIdx: 2,
+            loadAmount: 2000,
+            coin: 0,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        });
+        
+        await bb.build();
+        const input = bb.getInput();
+        
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+        
+        await rollupDB.consolidate(bb);
+        
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+        
+        const tx = {
+            fromIdx: 1,
+            toIdx: 2,
+            loadAmount: 100,
+            coin: 0,
+            amount: 50,
+            nonce: 0,
+            userFee: 10
+        };
+        account1.signTx(tx);
+        bb2.addTx(tx);
+        bb2.addCoin(0, 5);
+        try {
+            await bb2.build();
+            const input2 = bb2.getInput();
+            const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+            checkBatch(circuit, w2, bb2);
+        } catch (error) {
+            assert.include(error.message, "Load ammount must be 0 for offChainTxs");
+        }
+
+    });
+    it("Should check onchain transfer", async () => {
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+                
+        const account1 = new RollupAccount(1);
+        const account2 = new RollupAccount(2);
+                
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+                
+        bb.addTx({
+            fromIdx: 2,
+            loadAmount: 2000,
+            coin: 0,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        });
+                
+        await bb.build();
+        const input = bb.getInput();
+
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+                
+        await rollupDB.consolidate(bb);
+                
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+                
+        const tx = {
+            fromIdx: 2,
+            toIdx: 1,
+            coin: 0,
+            amount: 50,
+            nonce: 0,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        };
+        bb2.addTx(tx);
+
+        await bb2.build();
+        const input2 = bb2.getInput();
+        const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w2, bb2);
+
+    });
+
+    it("Should check onchain transfer to 0 with the wrong account", async () => {
+        //Never should happen, cause SC dont allow this
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+                
+        const account1 = new RollupAccount(1);
+        const account2 = new RollupAccount(2);
+                
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+                
+        bb.addTx({
+            fromIdx: 2,
+            loadAmount: 2000,
+            coin: 0,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        });
+                
+        await bb.build();
+        const input = bb.getInput();
+
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+                
+        await rollupDB.consolidate(bb);
+                
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+                
+        const tx = {
+            fromIdx: 1,
+            toIdx: 0,
+            coin: 0,
+            amount: 50,
+            nonce: 0,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        };
+        bb2.addTx(tx);
+
+        await bb2.build();
+        const input2 = bb2.getInput();
+        const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+        try{
+            checkBatch(circuit, w2, bb2);
+        }
+        catch(error){
+            assert.include(error.message, "AssertionError");
+        }
+
+    });
+
+    it("Should check 2 onchain transfer to 0 in the same batch", async () => {
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+                
+        const account1 = new RollupAccount(1);
+        const account2 = new RollupAccount(2);
+                
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+                
+        bb.addTx({
+            fromIdx: 2,
+            loadAmount: 2000,
+            coin: 0,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        });
+                
+        await bb.build();
+        const input = bb.getInput();
+
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+                
+        await rollupDB.consolidate(bb);
+                
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+                
+        const tx = {
+            fromIdx: 1,
+            toIdx: 0,
+            coin: 0,
+            amount: 50,
+            nonce: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        };
+        const tx2 = {
+            fromIdx: 1,
+            toIdx: 0,
+            coin: 0,
+            amount: 100,
+            nonce: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        };
+        bb2.addTx(tx);
+        bb2.addTx(tx2);
+        await bb2.build();
+        const input2 = bb2.getInput();
+        const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w2, bb2);
+        await rollupDB.consolidate(bb2);
+        const s2_1 = await rollupDB.getStateByIdx(1);
+        const s2_2 = await rollupDB.getStateByIdx(2);
+        assert.equal(s2_1.amount.toString(), 850);
+        assert.equal(s2_2.amount.toString(), 2000);
+
+
+    });
+    it("Should check 2 onchain transfer to 0 and a transfer in the same batch", async () => {
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+                
+        const account1 = new RollupAccount(1);
+        const account2 = new RollupAccount(2);
+                
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+                
+        bb.addTx({
+            fromIdx: 2,
+            loadAmount: 2000,
+            coin: 0,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        });
+                
+        await bb.build();
+        const input = bb.getInput();
+
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+                
+        await rollupDB.consolidate(bb);
+                
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+                
+        const tx = {
+            fromIdx: 1,
+            toIdx: 0,
+            coin: 0,
+            amount: 50,
+            nonce: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        };
+        const tx2 = {
+            fromIdx: 1,
+            toIdx: 0,
+            coin: 0,
+            amount: 100,
+            nonce: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        };
+        const tx3 = {
+            fromIdx: 2,
+            toIdx: 1,
+            coin: 0,
+            amount: 100,
+            nonce: 0,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        };
+        bb2.addTx(tx);
+        bb2.addTx(tx2);
+        bb2.addTx(tx3);
+        await bb2.build();
+        const input2 = bb2.getInput();
+        const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w2, bb2);
+        await rollupDB.consolidate(bb2);
+        const s2_1 = await rollupDB.getStateByIdx(1);
+        const s2_2 = await rollupDB.getStateByIdx(2);
+        assert.equal(s2_1.amount.toString(), 950);
+        assert.equal(s2_2.amount.toString(), 1900);
+
+
+    });
+    it("Should check onchain deposit on Top", async () => {
+        // Deposit on existing leaf.
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+        
+        const account1 = new RollupAccount(1);
+        const account2 = new RollupAccount(2);
+        
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+        
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 2000,
+            coin: 0,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        });
+        
+        await bb.build();
+        const input = bb.getInput();
+        
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+    });
+
+    it("Should check deposit and combined deposit transfer", async () => {
+
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+
+        const account1 = new RollupAccount(1);
+        const account2 = new RollupAccount(2);
+
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+
+        await bb.build();
+        const input = bb.getInput();
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+
+        await rollupDB.consolidate(bb);
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+
+        bb2.addTx({
+            fromIdx: 2,
+            toIdx: 1,
+            loadAmount: 1000,
+            amount: 500,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        });
+
+        await bb2.build();
+        const input2 = bb2.getInput();
+        const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w2, bb2);
+
+        await rollupDB.consolidate(bb2);
+        const s2_1 = await rollupDB.getStateByIdx(1);
+        assert.equal(s2_1.amount, 1500);
+
+        const s2_2 = await rollupDB.getStateByIdx(2);
+        assert.equal(s2_2.amount, 500);
+
+    });
+    it("Should check combined deposit and transfer to 0", async () => {
+        //Deposit and exit
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+
+        const account1 = new RollupAccount(1);
+
+        bb.addTx({
+            fromIdx: 1,
+            toIdx: 0,
+            loadAmount: 1000,
+            amount: 500,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+
+        await bb.build();
+        const input = bb.getInput();
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+        await rollupDB.consolidate(bb);
+        const s2_1 = await rollupDB.getStateByIdx(1);
+        assert.equal(s2_1.amount, 500);
+
+    });
+    it("Should check offchain with invalid fee", async () => { 
         // Start a new state
         const db = new SMTMemDB();
         const rollupDB = await RollupDB(db);
@@ -415,24 +1324,26 @@ describe("Rollup Basic circuit TXs", function () {
 
         const tx = {
             fromIdx: 1,
-            toIdx: 0,
+            toIdx: 2,
             coin: 0,
             amount: 50,
             nonce: 0,
-            userFee: 10
+            userFee: 0
         };
         account1.signTx(tx);
         bb2.addTx(tx);
+
         bb2.addCoin(0, 5);
-       
-        await bb2.build();
-        const input2 = bb2.getInput();
-        const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
-        checkBatch(circuit, w2, bb2);
+        try{
+            await bb2.build();
+            const input2 = bb2.getInput();
+            const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+            checkBatch(circuit, w2, bb2);
+        } catch (error) {
+            assert.include(error.message, "Constraint doesn't match main.Tx[0].balancesUpdater");
+        }
     });
-
-    it("Should create 1 deposit and combined deposit transfer", async () => {
-
+    it("Should check offchain with invalid nonce", async () => {
         // Start a new state
         const db = new SMTMemDB();
         const rollupDB = await RollupDB(db);
@@ -451,19 +1362,9 @@ describe("Rollup Basic circuit TXs", function () {
             onChain: true
         });
 
-        await bb.build();
-        const input = bb.getInput();
-        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
-        checkBatch(circuit, w, bb);
-
-        await rollupDB.consolidate(bb);
-        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
-
-        bb2.addTx({
+        bb.addTx({
             fromIdx: 2,
-            toIdx: 1,
-            loadAmount: 1000,
-            amount: 500,
+            loadAmount: 2000,
             coin: 0,
             ax: account2.ax,
             ay: account2.ay,
@@ -471,47 +1372,292 @@ describe("Rollup Basic circuit TXs", function () {
             onChain: true
         });
 
-        await bb2.build();
-        const input2 = bb2.getInput();
-        const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
-        checkBatch(circuit, w2, bb2);
+        await bb.build();
+        const input = bb.getInput();
 
-        await rollupDB.consolidate(bb2);
-        const s2_1 = await rollupDB.getStateByIdx(1);
-        assert.equal(s2_1.amount, 1500);
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
 
-        const s2_2 = await rollupDB.getStateByIdx(2);
-        assert.equal(s2_2.amount, 500);
+        await rollupDB.consolidate(bb);
 
-    });
-    it("Should create 2 deposits and then a normal offchain transfer", async () => {
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
 
-    });
-    it("Should check underflow onchain", async () => {
-    });
-    it("Should check underflow offchain", async () => {
-    });
-    it("Should check offchain with loadAmount", async () => {
-    });
-    it("Should check onchain transfer", async () => {
-    });
-    it("Should check onchain deposit existing", async () => {
-    });
-    it("Should check combined deposit transfer", async () => {
-    });
-    it("Should check combined deposit exit", async () => {
-    });
-    it("Should check offchain with invalid fee", async () => {
-    });
-    it("Should check offchain with invalid nonce", async () => {
+        const tx = {
+            fromIdx: 1,
+            toIdx: 2,
+            coin: 0,
+            amount: 50,
+            nonce: 0,
+            userFee: 10
+        };
+        const tx2 = {
+            fromIdx: 1,
+            toIdx: 2,
+            coin: 0,
+            amount: 50,
+            nonce: 0,
+            userFee: 10
+        };
+        account1.signTx(tx);
+        account1.signTx(tx2);
+        bb2.addTx(tx);
+        bb2.addTx(tx2);
+
+        bb2.addCoin(0, 5);
+        try {
+            await bb2.build();
+            const input2 = bb2.getInput();
+            const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+            checkBatch(circuit, w2, bb2);
+        } catch (error) {
+            assert.include(error.message, "Constraint doesn't match main.Tx[1].nonceChecker");
+        }
     });
     it("Should check offchain with invalid signature", async () => {
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+        
+        const account1 = new RollupAccount(1);
+        const account2 = new RollupAccount(2);
+        
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+        
+        bb.addTx({
+            fromIdx: 2,
+            loadAmount: 2000,
+            coin: 0,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        });
+        
+        await bb.build();
+        const input = bb.getInput();
+        
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+        
+        await rollupDB.consolidate(bb);
+        
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+        
+        const tx = {
+            fromIdx: 1,
+            toIdx: 2,
+            coin: 0,
+            amount: 50,
+            nonce: 0,
+            userFee: 10
+        };
+        account2.signTx(tx);
+        bb2.addTx(tx);
+        
+        bb2.addCoin(0, 5);
+        try{
+            await bb2.build();
+            const input2 = bb2.getInput();
+            const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+            checkBatch(circuit, w2, bb2);
+        } catch (error) {
+            assert.include(error.message, "Constraint doesn't match main.Tx[0].sigVerifier.eqCheckX");
+        }
     });
     it("Should check offchain with not defined coin", async () => {
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+        
+        const account1 = new RollupAccount(1);
+        const account2 = new RollupAccount(2);
+        
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+        
+        bb.addTx({
+            fromIdx: 2,
+            loadAmount: 2000,
+            coin: 0,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        });
+        
+        await bb.build();
+        const input = bb.getInput();
+        
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+        
+        await rollupDB.consolidate(bb);
+        
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+        
+        const tx = {
+            fromIdx: 1,
+            toIdx: 2,
+            coin: 2,
+            amount: 50,
+            nonce: 0,
+            userFee: 10
+        };
+        account1.signTx(tx);
+        bb2.addTx(tx);
+        
+        bb2.addCoin(1, 5);
+        try {
+            await bb2.build();
+            const input2 = bb2.getInput();
+            const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+            checkBatch(circuit, w2, bb2);
+        } catch (error) {
+            assert.include(error.message, "Constraint doesn't match main.Tx[0].processor1.checkOldInput");
+        }
+ 
     });
     it("Should check offchain with double defined coin", async () => {
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+        
+        const account1 = new RollupAccount(1);
+        const account2 = new RollupAccount(2);
+        
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+        
+        bb.addTx({
+            fromIdx: 2,
+            loadAmount: 2000,
+            coin: 1,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        });
+        
+        await bb.build();
+        const input = bb.getInput();
+        
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+        
+        await rollupDB.consolidate(bb);
+        
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+        
+        const tx = {
+            fromIdx: 1,
+            toIdx: 2,
+            coin: 0,
+            amount: 50,
+            nonce: 0,
+            userFee: 10
+        };
+        account1.signTx(tx);
+        bb2.addTx(tx);
+        
+        bb2.addCoin(0, 5);
+        try{ 
+            await bb2.build();
+            const input2 = bb2.getInput();
+                
+            const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+            checkBatch(circuit, w2, bb2);
+        } catch (error) {
+            assert.include(error.message, "Constraint doesn't match main.Tx[0].processor2.checkOldInput");
+        }
+
     });
-    it("Should check batch with invalid order", async () => {
+    it("Should check batch with invalid order", async () => { //dont know if its right
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(NTX, NLEVELS);
+ 
+        const account1 = new RollupAccount(1);
+        const account2 = new RollupAccount(2);
+ 
+        bb.addTx({
+            fromIdx: 1,
+            loadAmount: 1000,
+            coin: 0,
+            ax: account1.ax,
+            ay: account1.ay,
+            ethAddress: account1.ethAddress,
+            onChain: true
+        });
+ 
+        bb.addTx({
+            fromIdx: 2,
+            loadAmount: 2000,
+            coin: 0,
+            ax: account2.ax,
+            ay: account2.ay,
+            ethAddress: account2.ethAddress,
+            onChain: true
+        });
+ 
+        await bb.build();
+        const input = bb.getInput();
+ 
+        const w = circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        checkBatch(circuit, w, bb);
+ 
+        await rollupDB.consolidate(bb);
+ 
+        const bb2 = await rollupDB.buildBatch(NTX, NLEVELS);
+ 
+        const tx = {
+            fromIdx: 1,
+            toIdx: 2,
+            coin: 0,
+            amount: 50,
+            nonce: 0,
+            userFee: 10
+        };
+        account1.signTx(tx);
+        bb2.addTx(tx);
+ 
+        bb2.addCoin(0, 5);
+        
+        await bb2.build();
+        const input2 = bb2.getInput();
+         
+        const w2 = circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+        try{
+            checkBatch(circuit, w2, bb);
+        }
+        catch(error){
+            assert.include(error.message, "AssertionError");
+        }
     });
 });
 


### PR DESCRIPTION
Batcbuilder:
- The nonce of exit tree always should be 0, no need to update it.
- There's no overflow in the circuit, it overflows at 192 bits, but cause SC forces the maximum to 128 bits, it requires 2^64 Tx in order to overflow. Ethereum so far have 5*10^8 in 4 years, so it's needed 10^10 * 4 years. So will never overflow, or we will have time to update it ;)
