### PR TITLE
PoS msg sender must be controller address

### DIFF
--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -66,7 +66,7 @@ contract Rollup is Ownable, RollupHelpers, RollupInterface {
     uint256 totalFillingOnChainFee;
 
     // Fees recollected for every on-chain transaction
-    uint constant FEE_ONCHAIN_TX = 0.1 ether;
+    uint public constant FEE_ONCHAIN_TX = 0.1 ether;
 
     // maximum on-chain transactions
     uint public MAX_ONCHAIN_TX;

--- a/contracts/RollupPoS.sol
+++ b/contracts/RollupPoS.sol
@@ -17,7 +17,7 @@ contract RollupPoS is RollupPoSHelpers{
     uint constant public SLOT_DEADLINE = 20;
 
     // Minimum stake to enter the raffle
-    uint constant MIN_STAKE = 1 ether;
+    uint public constant MIN_STAKE = 1 ether;
 
     // First block where the first era begins
     uint public genesisBlock;
@@ -578,6 +578,8 @@ contract RollupPoS is RollupPoSHelpers{
         uint32 slot = currentSlot();
         uint opId = getRaffleWinner(slot);
         Operator storage op = operators[opId];
+        // message sender must be the controller address
+        require(msg.sender == op.controllerAddress, 'message sender must be controllerAddress');
         // operator must know data to generate current hash
         require(keccak256(abi.encodePacked(previousRndHash)) == op.rndHash,
             'hash revealed not match current committed hash');
@@ -610,6 +612,8 @@ contract RollupPoS is RollupPoSHelpers{
         uint32 slot = currentSlot();
         uint opId = getRaffleWinner(slot);
         Operator storage op = operators[opId];
+        // message sender must be the controller address
+        require(msg.sender == op.controllerAddress, 'message sender must be controllerAddress');
         uint32 updateEra = currentEra() + 2;
         _updateRaffles();
         Raffle storage raffle = raffles[updateEra];

--- a/rollup-operator/test/synch-archive.test.js
+++ b/rollup-operator/test/synch-archive.test.js
@@ -68,7 +68,7 @@ contract("Synchronizer - archive mode", (accounts) => {
         const inputSm = buildInputSm(batch, beneficiary);
         ptr = ptr - 1;
         await insRollupPoS.commitAndForge(hashChain[ptr] , `0x${batch.getDataAvailable().toString("hex")}`,
-            proofA, proofB, proofC, inputSm);
+            proofA, proofB, proofC, inputSm, {from: op1});
         await opRollupDb.consolidate(batch);
     }
 

--- a/rollup-operator/test/synch-full.test.js
+++ b/rollup-operator/test/synch-full.test.js
@@ -68,7 +68,7 @@ contract("Synchronizer - full mode", (accounts) => {
         const inputSm = buildInputSm(batch, beneficiary);
         ptr = ptr - 1;
         await insRollupPoS.commitAndForge(hashChain[ptr] , `0x${batch.getDataAvailable().toString("hex")}`,
-            proofA, proofB, proofC, inputSm);
+            proofA, proofB, proofC, inputSm, {from: op1});
         await opRollupDb.consolidate(batch);
     }
 

--- a/rollup-operator/test/synch-light.test.js
+++ b/rollup-operator/test/synch-light.test.js
@@ -68,7 +68,7 @@ contract("Synchronizer - light mode", (accounts) => {
         const inputSm = buildInputSm(batch, beneficiary);
         ptr = ptr - 1;
         await insRollupPoS.commitAndForge(hashChain[ptr] , `0x${batch.getDataAvailable().toString("hex")}`,
-            proofA, proofB, proofC, inputSm);
+            proofA, proofB, proofC, inputSm, {from: op1});
         await opRollupDb.consolidate(batch);
     }
 

--- a/rollup-operator/test/synch-pos.test.js
+++ b/rollup-operator/test/synch-pos.test.js
@@ -12,7 +12,7 @@ const timeTravel = require("../../test/contracts/helpers/timeTravel");
 const { timeout } = require("../src/utils");
 
 // timeouts test
-const timeoutDelay = 7500;
+const timeoutDelay = 10000;
 let timeoutSynch;
 let timeoutCheck;
 

--- a/rollup-operator/test/test.md
+++ b/rollup-operator/test/test.md
@@ -16,13 +16,13 @@ Test Rollup synchronizer on `light` mode:
   - `truffle test ./rollup-operator/test/synch-light.test.js`
 
 Test Rollup synchronizer on `full` mode:
-  - `truffle test ./rollup-operator/test/synch-light.test.js`
+  - `truffle test ./rollup-operator/test/synch-full.test.js`
 
 Test Rollup synchronizer on `archive` mode:
-  - `truffle test ./rollup-operator/test/synch-light.test.js`
+  - `truffle test ./rollup-operator/test/synch-archive.test.js`
 
 Test operator manager:
-  - `truffle test ./rollup-operator/test/op-manager.test.js `
+  - `truffle test ./rollup-operator/test/op-manager.test.js`
 
 ## Test server proof
 

--- a/test/contracts/Rollup-PoS-integration.test.js
+++ b/test/contracts/Rollup-PoS-integration.test.js
@@ -178,9 +178,8 @@ contract("Rollup - RollupPoS", (accounts) => {
         // Check balances
         const balOpBeforeForge = await getEtherBalance(operator1);
         // Forge genesis batch by operator 1
-        await insRollupPoS.commitBatch(hashChain[3], `0x${block.getDataAvailable().toString("hex")}`);
-        await insRollupPoS.forgeCommittedBatch(proofA, proofB, proofC, inputs);
-
+        await insRollupPoS.commitBatch(hashChain[3], `0x${block.getDataAvailable().toString("hex")}`, {from: operator1});
+        await insRollupPoS.forgeCommittedBatch(proofA, proofB, proofC, inputs, {from: operator1});
         // Build inputs
         const block1 = await rollupDB.buildBatch(maxTx, nLevels);
         const tx = manageEvent(eventTmp.logs[0]);
@@ -189,8 +188,8 @@ contract("Rollup - RollupPoS", (accounts) => {
         const inputs1 = buildInputSm(block1);
 
         // Forge batch by operator 1
-        await insRollupPoS.commitBatch(hashChain[2], `0x${block1.getDataAvailable().toString("hex")}`);
-        await insRollupPoS.forgeCommittedBatch(proofA, proofB, proofC, inputs1);
+        await insRollupPoS.commitBatch(hashChain[2], `0x${block1.getDataAvailable().toString("hex")}`, {from: operator1});
+        await insRollupPoS.forgeCommittedBatch(proofA, proofB, proofC, inputs1, {from: operator1});
         // Check balances
         const balOpAfterForge = await getEtherBalance(operator1);
         expect(Math.ceil(balOpBeforeForge) + 1).to.be.equal(Math.ceil(balOpAfterForge));

--- a/test/contracts/RollupPoS-functionalities.test.js
+++ b/test/contracts/RollupPoS-functionalities.test.js
@@ -295,7 +295,7 @@ contract("RollupPoS", (accounts) => {
             // try to commit batch with wrong previous hash
             let index = await getIndexHash(opId);
             try {
-                await insRollupPoS.commitBatch(hashChain[index - 2], compressedTxTest);
+                await insRollupPoS.commitBatch(hashChain[index - 2], compressedTxTest, {from: operators[0].address});
                 // above function should trigger an error
                 // otherwise test should not pass
                 expect(true).to.be.equal(false);
@@ -304,7 +304,7 @@ contract("RollupPoS", (accounts) => {
             }
 
             // check commit hash
-            const resCommit = await insRollupPoS.commitBatch(hashChain[index - 1], compressedTxTest);
+            const resCommit = await insRollupPoS.commitBatch(hashChain[index - 1], compressedTxTest, {from: operators[0].address});
             expect(resCommit.logs[0].event).to.be.equal("dataCommitted");
             expect(resCommit.logs[0].args.hashOffChain.toString()).to.be.equal(hashOffChain);
             // Get compressedTx from block number
@@ -321,7 +321,7 @@ contract("RollupPoS", (accounts) => {
             expect(`0x${compressedTxTest.toString("hex")}`).to.be.equal(inputRetrieved);
             // try to update data committed before without forging
             try {
-                await insRollupPoS.commitBatch(hashChain[index - 1], compressedTxTest);
+                await insRollupPoS.commitBatch(hashChain[index - 1], compressedTxTest, {from: operators[0].address});
                 // above function should trigger an error
                 // otherwise test should not pass
                 expect(true).to.be.equal(false);
@@ -330,7 +330,7 @@ contract("RollupPoS", (accounts) => {
             }
             
             // Forge batch
-            await insRollupPoS.forgeCommittedBatch(proofA, proofB, proofC, input);
+            await insRollupPoS.forgeCommittedBatch(proofA, proofB, proofC, input, {from: operators[0].address});
 
             // Check raffle random number has been updated
             currentRaffleRandom = await insRollupPoS.getRaffle(5); // currentEra + 2 = 3 + 2 = 5
@@ -339,7 +339,7 @@ contract("RollupPoS", (accounts) => {
 
             // try to forge data when there is no data committed
             try {
-                await insRollupPoS.forgeCommittedBatch(proofA, proofB, proofC, input);
+                await insRollupPoS.forgeCommittedBatch(proofA, proofB, proofC, input, {from: operators[0].address});
                 // above function should trigger an error
                 // otherwise test should not pass
                 expect(true).to.be.equal(false);
@@ -351,8 +351,8 @@ contract("RollupPoS", (accounts) => {
                 // commit data just before deadline
                 index = await getIndexHash(opId);
                 await insRollupPoS.setBlockNumber(eraBlock[3] + blocksPerSlot - deadlineBlocks - 2);
-                await insRollupPoS.commitBatch(hashChain[index - 1], compressedTxTest);
-                await insRollupPoS.forgeCommittedBatch(proofA, proofB, proofC, input);
+                await insRollupPoS.commitBatch(hashChain[index - 1], compressedTxTest, {from: operators[0].address});
+                await insRollupPoS.forgeCommittedBatch(proofA, proofB, proofC, input, {from: operators[0].address});
 
                 // Check raffle random number has been updated
                 currentRaffleRandom = await insRollupPoS.getRaffle(5); // currentEra + 2 = 3 + 2 = 5
@@ -363,7 +363,7 @@ contract("RollupPoS", (accounts) => {
                 await insRollupPoS.setBlockNumber(eraBlock[3] + blocksPerSlot - deadlineBlocks + 1);
                 index = await getIndexHash(opId);
                 try { 
-                    await insRollupPoS.commitBatch(hashChain[index - 1], compressedTxTest);
+                    await insRollupPoS.commitBatch(hashChain[index - 1], compressedTxTest, {from: operators[0].address});
                     // above function should trigger an error
                     // otherwise test should not pass
                     expect(true).to.be.equal(false);
@@ -385,15 +385,15 @@ contract("RollupPoS", (accounts) => {
 
                 // commit data before deadline, try to update it, not forge block and slash operator
                 // commit and forge
-                await insRollupPoS.commitBatch(hashChain[index - 1], compressedTxTest);
-                await insRollupPoS.forgeCommittedBatch(proofA, proofB, proofC, input);
+                await insRollupPoS.commitBatch(hashChain[index - 1], compressedTxTest, {from: operators[0].address});
+                await insRollupPoS.forgeCommittedBatch(proofA, proofB, proofC, input, {from: operators[0].address});
                 // commit again but not forge
                 index = await getIndexHash(opId);
-                await insRollupPoS.commitBatch(hashChain[index - 1], compressedTxTest);
+                await insRollupPoS.commitBatch(hashChain[index - 1], compressedTxTest, {from: operators[0].address});
                 // move forward and try to update committed info after deadline
                 await insRollupPoS.setBlockNumber(eraBlock[3] + blocksPerSlot + blocksPerSlot - deadlineBlocks + 1);
                 try {
-                    await insRollupPoS.commitBatch(hashChain[index - 1], compressedTxTest);
+                    await insRollupPoS.commitBatch(hashChain[index - 1], compressedTxTest, {from: operators[0].address});
                     // above function should trigger an error
                     // otherwise test should not pass
                     expect(true).to.be.equal(false);


### PR DESCRIPTION
RollupPoS must check if the message sender is the controller address, discarding the hash chain as an authentication method