### PR TITLE
skip pass on synch mode

### DIFF
--- a/rollup-operator/src/server/operator.js
+++ b/rollup-operator/src/server/operator.js
@@ -93,12 +93,15 @@ let pool;
     }
 
     // Check if password is on environment variables
+    // skip it if synch mode is ON
     let passString;
-    if (checkPassEnv()){
-        // ask password by console
-        passString = await getPassword();
-    } else {
-        passString = process.env.PASSWORD;
+    if (!onlySynch){
+        if (checkPassEnv()){
+            // ask password by console
+            passString = await getPassword();
+        } else {
+            passString = process.env.PASSWORD;
+        }
     }
 
     // Set default environment data if it is not specified


### PR DESCRIPTION
- skip asking password on console if operator runs in `synch` mode
- improve batch synchronization by saving `blockNumber` for each batch
  - considering 24 blocks as data immutability