### PR TITLE
add rollup address endpoints. update tutorial.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ For more on zkRollup checkout our docs [here](https://docs.iden3.io/#/rollup/rol
 ### Testnet details
 We've currently deployed an operator and the relevant contracts to the Goerli Testnet:
 
-1. **[Rollup.sol](https://github.com/iden3/rollup/blob/testnet/contracts/Rollup.sol)** manages the rollup itself: https://goerli.etherscan.io/address/0xXXXXXX
-2. **[RollupPoS.sol](https://github.com/iden3/rollup/blob/testnet/contracts/RollupPoS.sol)** manages the consensus mechanism; in this case PoS: https://goerli.etherscan.io/address/0xXXXXXX
+1. **[Rollup.sol](https://github.com/iden3/rollup/blob/testnet-2.0/contracts/Rollup.sol)** manages the rollup itself: https://goerli.etherscan.io/address/0xbC0fd0Bd2e5B5CC7FE947A829067D207381E03FA
+2. **[RollupPoB.sol](https://github.com/iden3/rollup/blob/testnet-2.0/contracts/RollupPoB.sol)** manages the consensus mechanism; in this case PoB: https://goerli.etherscan.io/address/0x4F0b91B8117b1Ac65ceE31efAbeafbBBEFeDcC38
 
 This testnet is purely for transfers (not arbitrary smart contracts), and fully supports ERC20 tokens.
 
@@ -74,7 +74,7 @@ The first step is to clone the rollup repository and move to the testnet branch:
 ```bash=
 git clone https://github.com/iden3/rollup.git
 cd rollup
-git checkout testnet
+git checkout testnet-2.0
 ```
 
 Next, install the required dependencies inside the relevant folders:
@@ -156,20 +156,20 @@ node cli.js onchaintx --type deposit --loadamount <amount> --tokenid 0 --configp
 
 Note that deposits may take 2 minutes to be forged. 
 
-As before, you should see a transaction hash. You can use the this hash to [track its progress](https://goerli.etherscan.io/).
+As before, you should see a transaction hash. You can use this hash to [track its progress](https://goerli.etherscan.io/).
 
 ### 2.6. Get your rollup account status<a id="2_6"></a>
 
 To find out what your rollup account status is, use either one of the following commands:
 
 ```bash=
-node cli.js info --type accounts --filter ethereum -c config-example.json
+node cli.js info --type accounts --filter ethereum --configpath config-example.json
 ```
 
 Or
 
 ```bash=
-node cli.js info --type accounts --filter babyjubjub -c config-example.json
+node cli.js info --type accounts --filter babyjubjub --configpath config-example.json
 ```
 
 The return info will look like this:
@@ -192,12 +192,12 @@ Accounts found:
 Note that information retrieved prints all possible tokens attached to rollup account. If it is wanted to get information account for specific token, you can filter by token too:
 
 ```
-node cli.js info --type accounts --filter tokenid --tokenid <token ID> -c config-example.json
+node cli.js info --type accounts --filter tokenid --tokenid <token ID> --configpath config-example.json
 ```
 
 Also you could visit the following link to check your account state:
 
-https://zkrollup.iden3.net/accounts/:ax/:ay/:tokenid
+https://zkrollup.iden3.net/accounts/:rollupaddress/:tokenid
 
 ### 2.7. Send a rollup transaction to an operator<a id="2_7"></a>
 Now that you've created your rollup account, it's time to send your first rollup transaction!
@@ -206,8 +206,10 @@ To do this, execute the following command:
 
 > You'll need to replace the first `<rollup address>`  with the rollup public key compressed of the intended recipient. You'll also need to replace `<amount>` with the amount you wish to send, and `<fee>` with an appropriate fee (`50%` as an example).
 
+> If you do not know any fellow which holds a rollup account you can send a transaction to this rollup account: `0x861bea7cd14a6e9eb5514193cf8a3d3a5b827dc8c7ba6dbe2f0bd2bd7379c12b`
+
 ```bash=
-node cli.js offchaintx --type send --recipient <rollup address> --amount <amount> --fee <fee> --tokenid 0 -c config-example.json
+node cli.js offchaintx --type send --recipient <rollup address> --amount <amount> --fee <fee> --tokenid 0 --configpath config-example.json
 ```
 
 Congratulations on executing your first off-chain transaction! 🚀
@@ -226,7 +228,7 @@ To do this, execute the following command:
 
 
 ```bash=
-node cli.js offchaintx --type withdrawoffchain --amount <amount> --fee <fee> --tokenid 0 -c config-example.json
+node cli.js offchaintx --type withdrawoffchain --amount <amount> --fee <fee> --tokenid 0 --configpath config-example.json
 ```
 
 This effectively transfers tokens to the **exit tree** -- a Merkle tree dedicated to keeping track of withdrawals. From there, they can be withdrawn using the on-chain contract.
@@ -236,7 +238,7 @@ This effectively transfers tokens to the **exit tree** -- a Merkle tree dedicate
 Once the previous transaction has been forged, a new entry in the exit tree is created. You can check for this entry by executing the following command:
 
 ```bash=
-node cli.js info --type exits --tokenid 0 -c config-example.json
+node cli.js info --type exits --tokenid 0 --configpath config-example.json
 ```
 
 You'll receive a response that looks like this:
@@ -257,7 +259,7 @@ To do this, execute the following command:
 > Remember to replace `<numexitbatch>` with the batch number you obtained in the previous step.
 
 ```bash=
-node cli.js onchaintx --type withdraw --tokenid 0 --numexitbatch <numexitbatch> -c config-example.json
+node cli.js onchaintx --type withdraw --tokenid 0 --numexitbatch <numexitbatch> --configpath config-example.json
 ```
 
 Wait a couple of minutes and then visit [etherscan](https://goerli.etherscan.io/) to check that your transaction has gone through.
@@ -266,26 +268,27 @@ And voila! That's all there is to it :)
 
 ### 2.11. Bonus: create rollup account with an off-chain transaction<a id="2_11"></a>
 
-We are going to creare a rollup account which does not exist on rollup ledger and send some funds to it. This means that a rollup account could be created without going on-chain and does not then does not require any ether.
+We are going to creare a rollup account which does not exist on rollup ledger and send some funds to it. This means that a rollup account could be created without going on-chain and then does not require any ether in front.
 
-Get a valid rollup account from client or ask for rollup public key to some friend :)
+Get a valid rollup account from client or ask for a rollup public key to some friend which does not exist on rollup :)
 ```bash=
-node cli.js createkeys
+node cli.js createkeys --walletpath wallet-offchain.json
 ```
 
-Take `Rollup public key compressed` and perform the off-chain deposit:
+Take `Rollup address` from previous wallet and perform the off-chain deposit ( you need to specify the ethereum address that will be linked to this rollup account as well :)
 ```bash=
-node cli.js offchaintx --type depositoffchain --amount <amountToSend> --tokenid 0 --fee <feeToPay%> --ethereumaddress <address new rollup account> -r <rollup public key>
+node cli.js offchaintx --type depositoffchain --amount <amountToSend> --tokenid 0 --fee <feeToPay%> --ethereumaddress <address new rollup account> -r <rollup public key> --configpath config-example.json
 ```
 
-> In order to perform this deposit off-chain transaction, the operator must pay for an on-chain transaction and the creation of the rollup account. Transaction needs to cover this costs, otherwise operator will automatically reject the transaction. Current testnet implementation defines a `deposit fee = 0.0001 ether`. Taking into account that we consider `WEENUS token = 1$`, that would mean that, assuming ether value is 230$, deposit fee would cost 0.023 $. Therefore, to perform a deposit off-user, rollup user must pay fees that covers this deposit fees.
+Wait until the off-chain transaction has been forged and check the rollup accounts status in https://zkrollup.iden3.net/accounts/:rollupaddress/:tokenid to check that rollup account has been created succesfully 
 
+> In order to perform this deposit off-chain transaction, the operator must pay for the creation of the rollup account. Transaction needs to cover this costs, otherwise operator will automatically reject the transaction. Current testnet implementation defines a `deposit fee = 0.0001 ether`. Taking into account that we consider `WEENUS token (18 decimals) = 1$`, that would mean that, assuming ether value is 230$, deposit fee would cost 0.023 $. Therefore, to perform a deposit off-chain, rollup user must pay fees that covers this deposit fees.
 
 
 ### 2.12. Resources<a id="2_12"></a>
 
 - Checkout our github repository [here](https://github.com/iden3/rollup).
 
-- For more on how the rollup client works, see [here](https://github.com/iden3/rollup/blob/testnet/rollup-cli/README.md).
+- For more on how the rollup client works, see [here](https://github.com/iden3/rollup/blob/testnet-2.0/rollup-cli/README.md).
 
 - If you’d like to offer feedback, come across any problems, or have any questions at all, please feel free to reach out to us in our [telegram group](https://t.me/joinchat/G89XThj_TdahM0HASZEHwg).

--- a/js/rollupdb.js
+++ b/js/rollupdb.js
@@ -1,6 +1,7 @@
 const SMT = require("circomlib").SMT;
 const poseidon = require("circomlib").poseidon;
 const Scalar = require("ffjavascript").Scalar;
+const BabyJubJub = require("circomlib").babyJub;
 
 const SMTTmpDb = require("./smttmpdb");
 const BatchBuilder = require("./batchbuilder");
@@ -99,6 +100,7 @@ class RollupDB {
         if (!stateArray) return null;
         const st = utils.array2state(stateArray);
         st.idx = Number(idx);
+        st.rollupAddress = this.pointToCompress(st.ax, st.ay);
         return st;
     }
 
@@ -294,6 +296,20 @@ class RollupDB {
         if (indexFound !== null){
             states.splice(indexFound);
         }
+    }
+
+    /**
+     * Compute babyjubjub compressed address
+     * @param {String} ax - Ax coordinate encoded as hexadecimal string
+     * @param {String} ay - Ay coordinate encoded as hexadecimal string
+     * @returns {String} compressed bayjubjub address encoded as hexadecimal string
+     */
+    pointToCompress(axStr, ayStr){
+        const ax = Scalar.fromString(axStr, 16);
+        const ay = Scalar.fromString(ayStr, 16);
+        const compress = BabyJubJub.packPoint([ax, ay]);
+
+        return `0x${compress.toString("hex")}`;
     }
 }
 

--- a/rollup-operator/src/cli-external-operator.js
+++ b/rollup-operator/src/cli-external-operator.js
@@ -26,6 +26,16 @@ class CliExternalOperator {
     }
 
     /**
+     * Get account state
+     * @param {Number} coin - coin identifier
+     * @param {String} address - Public rollup address represented as an hex string
+     * @returns {Object} - http response 
+     */
+    getStateAccountByAddress(coin, address) {
+        return axios.get(`${this.url}/accounts/${address}/${coin}`);
+    }
+
+    /**
      * Get array of accounts depending on filters provided
      * @param {Object} filters
      * @returns {Object} - http response 
@@ -39,6 +49,15 @@ class CliExternalOperator {
         urlParams = urlParams.substring(0, urlParams.length - 1);
         
         return axios.get(`${this.url}/accounts${urlParams}`);
+    }
+
+    /**
+     * Get account states
+     * @param {String} address - Public rollup address represented as an hex string
+     * @returns {Object} - http response 
+     */
+    getAccountsByAddress(address) {
+        return axios.get(`${this.url}/accounts/${address}`);
     }
 
     /**

--- a/rollup-operator/src/synch.js
+++ b/rollup-operator/src/synch.js
@@ -11,6 +11,7 @@ const { timeout, purgeArray, padding256 } = require("./utils");
 const Constants = require("./constants");
 const GlobalConst = require("../../js/constants");
 
+const finalIdxInput = 0;
 const offChainHashInput = 4;
 const feePlanCoinsInput = 7;
 const feeTotals = 8;
@@ -650,6 +651,7 @@ class Synchronizer {
             }
         });
 
+        const inputFinalIdx = inputRetrieved[finalIdxInput];
         const inputOffChainHash = inputRetrieved[offChainHashInput];
         const inputFeePlanCoins = inputRetrieved[feePlanCoinsInput];
         const inputFeeTotals = inputRetrieved[feeTotals];
@@ -686,6 +688,7 @@ class Synchronizer {
             feePlanCoins: inputFeePlanCoins,
             feeTotals: inputFeeTotals,
             timestamp: await this._getTxTimestamp(hashOffChainTx),
+            totalAccounts: inputFinalIdx,
         };
     }
 

--- a/rollup-operator/test/server/proof-of-burn/operator-server-pob.test.js
+++ b/rollup-operator/test/server/proof-of-burn/operator-server-pob.test.js
@@ -389,6 +389,8 @@ contract("Operator", (accounts) => {
         const walletAx2 = rollupWallets[2].babyjubWallet.publicKey[0].toString(16);
         const walletAy2 = rollupWallets[2].babyjubWallet.publicKey[1].toString(16);
 
+        const coin = 0;
+
         // By Public key Babyjubjub
         let filters;
         let account;
@@ -504,6 +506,42 @@ contract("Operator", (accounts) => {
             expect(error.response.status).to.be.equal(404);
             expect(error.response.data).to.be.equal("Accounts not found");
         }
+
+        // By rollup address (babyjubjub compressed)
+        const resState = await cliExternalOp.getStateAccount(0, walletAx0, walletAy0);
+        const state = resState.data;
+
+        const rollupAddress = state.rollupAddress;
+
+        const resStateB = await cliExternalOp.getStateAccountByAddress(coin, rollupAddress);
+        const stateB = resStateB.data;
+        
+        const resStateC = await cliExternalOp.getAccountsByAddress(rollupAddress);
+        const stateC = resStateC.data[0];
+
+        expect(state.coin).to.be.equal(stateB.coin);
+        expect(stateB.coin).to.be.equal(stateC.coin);
+
+        expect(state.nonce).to.be.equal(stateB.nonce);
+        expect(stateB.nonce).to.be.equal(stateC.nonce);
+
+        expect(state.amount).to.be.equal(stateB.amount);
+        expect(stateB.amount).to.be.equal(stateC.amount);
+
+        expect(state.ax).to.be.equal(stateB.ax);
+        expect(stateB.ax).to.be.equal(stateC.ax);
+
+        expect(state.ay).to.be.equal(stateB.ay);
+        expect(stateB.ay).to.be.equal(stateC.ay);
+
+        expect(state.ethAddress).to.be.equal(stateB.ethAddress);
+        expect(stateB.ethAddress).to.be.equal(stateC.ethAddress);
+
+        expect(state.idx).to.be.equal(stateB.idx);
+        expect(stateB.idx).to.be.equal(stateC.idx);
+
+        expect(state.rollupAddress).to.be.equal(stateB.rollupAddress);
+        expect(stateB.rollupAddress).to.be.equal(stateC.rollupAddress);
     });
 
     it("Should check batch transactions", async () => {

--- a/rollup-operator/test/synch.test.js
+++ b/rollup-operator/test/synch.test.js
@@ -86,6 +86,7 @@ contract("Synchronizer", (accounts) => {
             compressedTxs: batch.getDataAvailableSM(), 
             feePlanCoins: Scalar.fromString(inputSm[7], 16),
             feeTotals: Scalar.fromString(inputSm[8], 16),
+            totalAccounts: Scalar.fromString(inputSm[0], 16),
         });
 
         // Test vector on-chain
@@ -728,6 +729,7 @@ contract("Synchronizer", (accounts) => {
             expect(offDataTest.compressedTxs).to.be.equal(offChainData.compressedTxs);
             expect(Scalar.eq(offDataTest.feePlanCoins, offChainData.feePlanCoins)).to.be.equal(true);
             expect(Scalar.eq(offDataTest.feeTotals, offChainData.feeTotals)).to.be.equal(true);
+            expect(Scalar.eq(offDataTest.totalAccounts, offChainData.totalAccounts)).to.be.equal(true);
         
             // Check on-chain data test
             const onChainData = batchData.onChainData;


### PR DESCRIPTION
- add operator endpoints using compressed babyjubjub address
- add `totalAccounts` number in batch information
- update `rollup-cli` tutorial